### PR TITLE
Corrige le lien vers la documentation d'un mécanisme

### DIFF
--- a/packages/react-ui/source/mecanisms/common.tsx
+++ b/packages/react-ui/source/mecanisms/common.tsx
@@ -145,7 +145,7 @@ const MecanismName = ({
 				name={name}
 				inline={inline}
 				target="_blank"
-				href={`https://publi.codes/docs/mécanismes#${name}`}
+				href={`https://publi.codes/docs/api/mécanismes#${name}`}
 			>
 				{children}
 			</StyledMecanismName>


### PR DESCRIPTION
Correction du lien vers la documentation d'un méchanisme au lieu d'une page 404