### PR TITLE
Ajout d'un export de parseExpression

### DIFF
--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -63,6 +63,7 @@ export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'
 export { parseUnit, serializeUnit } from './units'
 export { parsePublicodes, utils }
+export { parseExpression } from './parse'
 export { type Rule, type RuleNode, type ASTNode, type EvaluatedNode }
 
 export type PublicodesExpression = string | Record<string, unknown> | number

--- a/packages/core/source/parse.ts
+++ b/packages/core/source/parse.ts
@@ -86,7 +86,7 @@ Utilisez leur contrepartie française : 'oui' / 'non'`,
 
 const compiledGrammar = Grammar.fromCompiled(grammar)
 
-function parseExpression(
+export function parseExpression(
 	rawNode,
 	context: Context
 ): Record<string, unknown> | undefined {

--- a/packages/core/test/parseExpressions.ts
+++ b/packages/core/test/parseExpressions.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai'
+import Engine, { parseExpression } from '../source/index'
+
+describe("Enable external codebases to use publicodes's expression parser", () => {
+	it('parse expressions', () => {
+		const parsed = parseExpression('équipement * facteur')
+		expect(JSON.stringify(parsed)).to.equal(
+			JSON.stringify({
+				'*': [
+					{
+						variable: 'équipement',
+					},
+					{
+						variable: 'facteur',
+					},
+				],
+			})
+		)
+	})
+})


### PR DESCRIPTION
L'objectif, c'est que des bibliothèques comme datagir/publiopti puissent
modifier un arbre publicodes sans réimplémenter la logique des
expressions qui sont parsées par nearley dans publicodes.

Plus précisément, on vient de trouver un bug qui est du à la faiblesse des regexp JS par rapport à Nearley. D'où l'idée de se fournir directement à la source. 

https://github.com/datagir/publiopti/pull/8

- [ ] voir si le format de sortie de parseExpression nous permet de faire ce qu'on veut faire : resérialiser une expression publicodes simplifiée
- [ ] discuter de l'éventualité de l'intégrer dans la nouvelle version de publicodes 
