### PR TITLE
feat(react-ui): add a search bar

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -28,6 +28,7 @@
 		"dist"
 	],
 	"dependencies": {
+		"fuse.js": "^7.0.0",
 		"styled-components": "^6.1.1"
 	},
 	"peerDependencies": {

--- a/packages/react-ui/src/rule/RulePage.tsx
+++ b/packages/react-ui/src/rule/RulePage.tsx
@@ -109,7 +109,7 @@ function Rule({
 	dottedName,
 	language,
 	subEngineId,
-	searchBar,
+	searchBar = false,
 	apiDocumentationUrl,
 	apiEvaluateUrl,
 	npmPackage,
@@ -149,14 +149,10 @@ function Rule({
 					dottedName={dottedName}
 					mobileMenuPortalId={mobileMenuPortalId}
 					openNavButtonPortalId={openNavButtonPortalId}
+					searchBar={searchBar}
 				/>
 				<Article>
 					<DottedNameContext.Provider value={dottedName}>
-						{searchBar ?
-							<Suspense>
-								<RulesSearch />
-							</Suspense>
-						:	null}
 						<RuleHeader dottedName={dottedName} />
 						<section>
 							<Text>{description || question || ''}</Text>

--- a/packages/react-ui/src/rule/RulePage.tsx
+++ b/packages/react-ui/src/rule/RulePage.tsx
@@ -7,7 +7,7 @@ import Engine, {
 	serializeUnit,
 	utils,
 } from 'publicodes'
-import { lazy, Suspense, useContext, useEffect, useRef } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import { styled } from 'styled-components'
 import {
 	BasepathContext,
@@ -23,8 +23,6 @@ import { RuleLinkWithContext } from '../RuleLink'
 import { DeveloperAccordion } from './DeveloperAccordion'
 import RuleHeader from './Header'
 import { breakpointsWidth, RulesNav } from './RulesNav'
-
-const RulesSearch = lazy(() => import('./RulesSearch'))
 
 type RulePageProps = {
 	documentationPath: string

--- a/packages/react-ui/src/rule/RulePage.tsx
+++ b/packages/react-ui/src/rule/RulePage.tsx
@@ -7,7 +7,7 @@ import Engine, {
 	serializeUnit,
 	utils,
 } from 'publicodes'
-import { useContext, useEffect, useRef } from 'react'
+import { lazy, Suspense, useContext, useEffect, useRef } from 'react'
 import { styled } from 'styled-components'
 import {
 	BasepathContext,
@@ -24,12 +24,15 @@ import { DeveloperAccordion } from './DeveloperAccordion'
 import RuleHeader from './Header'
 import { breakpointsWidth, RulesNav } from './RulesNav'
 
+const RulesSearch = lazy(() => import('./RulesSearch'))
+
 type RulePageProps = {
 	documentationPath: string
 	rulePath: string
 	engine: Engine
 	language: 'fr' | 'en'
 	renderers: SupportedRenderers
+	searchBar?: boolean
 	apiDocumentationUrl?: string
 	apiEvaluateUrl?: string
 	npmPackage?: string
@@ -43,6 +46,7 @@ export default function RulePage({
 	rulePath,
 	engine,
 	renderers,
+	searchBar,
 	language,
 	apiDocumentationUrl,
 	apiEvaluateUrl,
@@ -78,6 +82,7 @@ export default function RulePage({
 						mobileMenuPortalId={mobileMenuPortalId}
 						openNavButtonPortalId={openNavButtonPortalId}
 						showDevSection={showDevSection}
+						searchBar={searchBar}
 					/>
 				</RenderersContext.Provider>
 			</BasepathContext.Provider>
@@ -97,12 +102,14 @@ type RuleProps = {
 	| 'mobileMenuPortalId'
 	| 'openNavButtonPortalId'
 	| 'showDevSection'
+	| 'searchBar'
 >
 
 function Rule({
 	dottedName,
 	language,
 	subEngineId,
+	searchBar,
 	apiDocumentationUrl,
 	apiEvaluateUrl,
 	npmPackage,
@@ -145,6 +152,11 @@ function Rule({
 				/>
 				<Article>
 					<DottedNameContext.Provider value={dottedName}>
+						{searchBar ?
+							<Suspense>
+								<RulesSearch />
+							</Suspense>
+						:	null}
 						<RuleHeader dottedName={dottedName} />
 						<section>
 							<Text>{description || question || ''}</Text>

--- a/packages/react-ui/src/rule/RulesNav.tsx
+++ b/packages/react-ui/src/rule/RulesNav.tsx
@@ -5,6 +5,7 @@ import { styled } from 'styled-components'
 import { RuleLinkWithContext } from '../RuleLink'
 import { Arrow } from '../component/icons'
 import { useEngine } from '../hooks'
+
 interface Props {
 	dottedName: string
 	mobileMenuPortalId?: string

--- a/packages/react-ui/src/rule/RulesNav.tsx
+++ b/packages/react-ui/src/rule/RulesNav.tsx
@@ -1,23 +1,38 @@
 import { utils } from 'publicodes'
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import {
+	Suspense,
+	lazy,
+	memo,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react'
 import ReactDOM from 'react-dom'
 import { styled } from 'styled-components'
 import { RuleLinkWithContext } from '../RuleLink'
 import { Arrow } from '../component/icons'
 import { useEngine } from '../hooks'
 
+const RulesSearch = lazy(() => import('./RulesSearch'))
+
 interface Props {
 	dottedName: string
+	searchBar: boolean
 	mobileMenuPortalId?: string
 	openNavButtonPortalId?: string
 }
 
 export const RulesNav = ({
 	dottedName,
+	searchBar,
 	mobileMenuPortalId,
 	openNavButtonPortalId,
 }: Props) => {
 	const baseEngine = useEngine()
+	const parsedRules = baseEngine.getParsedRules()
+	const parsedRulesNames = Object.keys(parsedRules)
+
 	const [navOpen, setNavOpen] = useState(false)
 
 	const initLevel = (dn: string) =>
@@ -30,10 +45,7 @@ export const RulesNav = ({
 
 	useEffect(() => {
 		setLevel((prev) => ({ ...prev, ...initLevel(dottedName) }))
-		setNavOpen(false)
 	}, [dottedName])
-
-	const parsedRules = baseEngine.getParsedRules()
 
 	const toggleDropdown = useCallback((ruleDottedName: string) => {
 		setLevel((prevLevel) =>
@@ -76,10 +88,15 @@ export const RulesNav = ({
 				)}
 
 			<Nav $open={navOpen}>
+				{searchBar ?
+					<Suspense fallback={<p>Chargement...</p>}>
+						<RulesSearch />
+					</Suspense>
+				:	null}
 				<ul>
-					{Object.entries(parsedRules)
-						.sort(([a], [b]) => a.localeCompare(b))
-						.map(([ruleDottedName]) => {
+					{parsedRulesNames
+						.sort((a, b) => a.localeCompare(b))
+						.map((ruleDottedName) => {
 							const parentDottedName = utils.ruleParent(ruleDottedName)
 
 							if (

--- a/packages/react-ui/src/rule/RulesSearch.tsx
+++ b/packages/react-ui/src/rule/RulesSearch.tsx
@@ -19,17 +19,18 @@ export default function RulesSearch() {
 		},
 	)
 	const [searchResults, setSearchResults] = useState<SearchableRule[]>([])
+	const [searchQuery, setSearchQuery] = useState('')
 
 	const fuse = new Fuse(rules, { keys: ['title', 'name'] })
 
-	const search = (query: string) => {
-		const results = fuse.search(query, { limit: 10 })
-		setSearchResults(results.map((result) => result.item))
-	}
+	useEffect(() => {
+		setSearchQuery('')
+	}, [dottedName])
 
 	useEffect(() => {
-		search('')
-	}, [dottedName])
+		const results = fuse.search(searchQuery, { limit: 10 })
+		setSearchResults(results.map((result) => result.item))
+	}, [searchQuery])
 
 	const isEmpty = searchResults.length === 0
 
@@ -39,8 +40,9 @@ export default function RulesSearch() {
 				id="documentation-search-input"
 				type="text"
 				placeholder="Chercher une règle"
-				onChange={(e) => search(e.target.value)}
-				onFocus={(e) => search(e.target.value)}
+				value={searchQuery}
+				onChange={(e) => setSearchQuery(e.target.value)}
+				onFocus={(e) => setSearchQuery(e.target.value)}
 				empty={isEmpty}
 			/>
 			{!isEmpty ?
@@ -52,15 +54,17 @@ export default function RulesSearch() {
 								key={name}
 								id="documentation-search-item"
 								isLast={isLast}
-								onClick={() => search('')}
+								onClick={() => setSearchQuery('')}
 							>
-								<RuleLinkWithContext dottedName={name} displayIcon={true}>
-									<ItemName id="documentation-search-item-name">
-										{name}
-									</ItemName>
-									<ItemTitle id="documentation-search-item-title">
-										{title}
-									</ItemTitle>
+								<RuleLinkWithContext dottedName={name}>
+									<ItemContent>
+										<ItemName id="documentation-search-item-name">
+											{name}
+										</ItemName>
+										<ItemTitle id="documentation-search-item-title">
+											{title}
+										</ItemTitle>
+									</ItemContent>
 								</RuleLinkWithContext>
 							</SearchItem>
 						)
@@ -72,7 +76,8 @@ export default function RulesSearch() {
 }
 
 const SearchContainer = styled.div`
-	margin-bottom: 1rem;
+	margin: 1rem;
+	max-width: 350px;
 `
 
 const SearchInput = styled.input<{ empty: boolean }>`
@@ -92,6 +97,7 @@ const SearchResults = styled.div`
 	border: 1px solid #ccc;
 	border-top: none;
 	border-radius: 0 0 0.25rem 0.25rem;
+	position: relative;
 `
 
 const SearchItem = styled.div<{ isLast: boolean }>`
@@ -104,11 +110,16 @@ const SearchItem = styled.div<{ isLast: boolean }>`
 		background-color: #f6f6f6;
 	}
 `
+const ItemContent = styled.span`
+	display: flex;
+	flex-wrap: wrap;
+	flex-gap: 0.5rem;
+	align-items: center;
+`
 
 const ItemName = styled.span`
 	width: 100%;
 `
 const ItemTitle = styled.span`
-	margin-left: 1rem;
 	color: #666;
 `

--- a/packages/react-ui/src/rule/RulesSearch.tsx
+++ b/packages/react-ui/src/rule/RulesSearch.tsx
@@ -48,16 +48,15 @@ export default function RulesSearch() {
 			{!isEmpty ?
 				<SearchResults id="documentation-search-results">
 					{searchResults.map(({ name, title }, i) => {
-						const isLast = i === searchResults.length - 1
 						return (
 							<SearchItem
 								key={name}
 								id="documentation-search-item"
-								isLast={isLast}
+								isLast={i === searchResults.length - 1}
 								onClick={() => setSearchQuery('')}
 							>
 								<RuleLinkWithContext dottedName={name}>
-									<ItemContent>
+									<ItemContent onClick={() => setSearchQuery('')}>
 										<ItemName id="documentation-search-item-name">
 											{name}
 										</ItemName>
@@ -76,7 +75,8 @@ export default function RulesSearch() {
 }
 
 const SearchContainer = styled.div`
-	margin: 1rem;
+	margin-bottom: 1rem;
+	margin-right: 1rem;
 	max-width: 350px;
 `
 

--- a/packages/react-ui/src/rule/RulesSearch.tsx
+++ b/packages/react-ui/src/rule/RulesSearch.tsx
@@ -1,0 +1,114 @@
+import { useContext, useEffect, useState } from 'react'
+import { useEngine } from '../hooks'
+import { styled } from 'styled-components'
+import Fuse from 'fuse.js'
+import { RuleLinkWithContext } from '../RuleLink'
+import { DottedNameContext } from '../contexts'
+
+type SearchableRule = {
+	name: string
+	title?: string
+}
+
+export default function RulesSearch() {
+	const engine = useEngine()
+	const dottedName = useContext(DottedNameContext)
+	const rules: SearchableRule[] = Object.entries(engine.getParsedRules()).map(
+		([name, rule]) => {
+			return { name, title: rule?.rawNode?.titre }
+		},
+	)
+	const [searchResults, setSearchResults] = useState<SearchableRule[]>([])
+
+	const fuse = new Fuse(rules, { keys: ['title', 'name'] })
+
+	const search = (query: string) => {
+		const results = fuse.search(query, { limit: 10 })
+		setSearchResults(results.map((result) => result.item))
+	}
+
+	useEffect(() => {
+		search('')
+	}, [dottedName])
+
+	const isEmpty = searchResults.length === 0
+
+	return (
+		<SearchContainer id="documentation-search">
+			<SearchInput
+				id="documentation-search-input"
+				type="text"
+				placeholder="Chercher une règle"
+				onChange={(e) => search(e.target.value)}
+				onFocus={(e) => search(e.target.value)}
+				empty={isEmpty}
+			/>
+			{!isEmpty ?
+				<SearchResults id="documentation-search-results">
+					{searchResults.map(({ name, title }, i) => {
+						const isLast = i === searchResults.length - 1
+						return (
+							<SearchItem
+								key={name}
+								id="documentation-search-item"
+								isLast={isLast}
+								onClick={() => search('')}
+							>
+								<RuleLinkWithContext dottedName={name} displayIcon={true}>
+									<ItemName id="documentation-search-item-name">
+										{name}
+									</ItemName>
+									<ItemTitle id="documentation-search-item-title">
+										{title}
+									</ItemTitle>
+								</RuleLinkWithContext>
+							</SearchItem>
+						)
+					})}
+				</SearchResults>
+			:	null}
+		</SearchContainer>
+	)
+}
+
+const SearchContainer = styled.div`
+	margin-bottom: 1rem;
+`
+
+const SearchInput = styled.input<{ empty: boolean }>`
+	width: 100%;
+	padding: 0.5rem;
+	border: 1px solid #ccc;
+	border-radius: ${({ empty }) => (empty ? '5px' : '5px 5px 0 0')};
+
+	&:focus {
+		outline: none;
+		border: 1px solid #666;
+	}
+`
+
+const SearchResults = styled.div`
+	background-color: white;
+	border: 1px solid #ccc;
+	border-top: none;
+	border-radius: 0 0 0.25rem 0.25rem;
+`
+
+const SearchItem = styled.div<{ isLast: boolean }>`
+	padding: 0.5rem;
+	border-bottom: ${({ isLast }) => (isLast ? 'none' : '1px solid #e6e6e6')};
+	border-left: 2px solid transparent;
+	border-radius: ${({ isLast }) => (isLast ? '0 0 0.25rem 0.25rem' : '0')};
+
+	&:hover {
+		background-color: #f6f6f6;
+	}
+`
+
+const ItemName = styled.span`
+	width: 100%;
+`
+const ItemTitle = styled.span`
+	margin-left: 1rem;
+	color: #666;
+`

--- a/website/docs/api/react-ui.mdx
+++ b/website/docs/api/react-ui.mdx
@@ -29,6 +29,8 @@ action (il est affiché sur l’écran de droite).
 - `rulePath`: (`string`) le chemin de la règle à afficher
 - `language`: le language dans lequel afficher la documentation (pour l’instant,
   seuls `fr` et `en` sont supportés).
+- `searchBar`: (`boolean`) affiche une barre de recherche pour naviguer dans la
+  documentation (par défaut à `false`)
 - `renderers`: `{ Head?: React.Component, Link: React.Component }` :
   les composants React qui seront utilisés dans la page de documentation.
   - `Link`: pour afficher les liens. Le composant prend un argument `to`

--- a/website/src/components/Documentation.tsx
+++ b/website/src/components/Documentation.tsx
@@ -121,6 +121,7 @@ export default function Documentation({
 					language={'fr'}
 					rulePath={ruleToPaths[currentTarget]?.replace(/^\//, '') || ''}
 					engine={engine}
+					searchBar={true}
 					documentationPath={''}
 					showDevSection={showDevSection}
 					renderers={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,7 @@ __metadata:
     "@types/react": ^18.2.23
     "@types/react-dom": ^18.0.11
     "@types/styled-components": ^5.1.28
+    fuse.js: ^7.0.0
     publicodes: "workspace:^"
     styled-components: ^6.1.1
     tsup: ^7.2.0
@@ -11430,6 +11431,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "fuse.js@npm:7.0.0"
+  checksum: d15750efec1808370c0cae92ec9473aa7261c59bca1f15f1cf60039ba6f804b8f95340b5cabd83a4ef55839c1034764856e0128e443921f072aa0d8a20e4cacf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces a new dependency `fuse.js` for the fuzzy search but the component is disabled by default and lazy loaded so it shouldn't be a problem no?

## Demo

![image](https://github.com/publicodes/publicodes/assets/44124798/08c130bb-08eb-4723-a642-f8410e28182c)

![image](https://github.com/publicodes/publicodes/assets/44124798/88a8168e-f37c-4ed7-8fcc-3e866f4f79e8)

![image](https://github.com/publicodes/publicodes/assets/44124798/54b3efa1-8da3-4f69-909c-164976a66405)

