### PR TITLE
Met à jour l'exemple d'appel à constantFolding

### DIFF
--- a/website/docs/tools/optim.mdx
+++ b/website/docs/tools/optim.mdx
@@ -87,10 +87,15 @@ import { constantFolding } from '@publicodes/tools/optims'
 const optimizedRules = constantFolding(
   // A publicode engine instantiated with the rules to optimize.
   new Engine(baseRules),
-  // A predicate returning true if the rule needs to be kept.
-  ([ruleName, ruleNode]) => {
-    return ['root', 'root . bis'].includes(ruleName) ||  ruleNode.rawNode['to keep']
-  }
+  {
+    // A predicate returning true if the rule needs to be kept.
+    toKeep: (rule) => {
+      return (
+        ['root', 'root . bis'].includes(rule.dottedName) ||
+        !!rule.rawNode['to keep']
+      )
+    },
+  },
 )
 ```
 


### PR DESCRIPTION
Je m'intéresse actuellement aux nouveaux mécanismes d'optimisation et il semble que la signature donnée en exemple n'est plus à jour.

Cette PR propose une mise à jour d'après la signature de la dernière version publiée.