### PR TITLE
perf: add a fine-grained cache for context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 1.3.2
+**@publicodes/core**
+
+- Perf : améliore les performance du mécanisme `contexte`. Si plusieurs contextes sont identiques, alors ils partagent un `subEngine` pour éviter de recalculer les mêmes règles plusieurs fois (#484)
+
 ## 1.3.1
 
 **@publicodes/core**
 
 - Fix `allowOrphanRules` option which was broken by 1.3.0
+
 
 ## 1.3.0
 

--- a/packages/core/bench/contexte.ts
+++ b/packages/core/bench/contexte.ts
@@ -1,0 +1,38 @@
+import { bench, group, run } from 'mitata'
+import modeleSocial from 'modele-social'
+import Publicodes from '../src/index'
+
+const engine = new Publicodes(modeleSocial, {
+	logger: { warn: () => {}, error: () => {}, log: () => {} },
+})
+
+const NUMBER_RULES = 15
+
+group('Contexte vs situation', () => {
+	const makeEval1 = () => ({
+		valeur: 'salarié . coût total employeur',
+	})
+	bench('Using the same situation', () => {
+		engine.setSituation({
+			'salarié . rémunération . net': 45000,
+		})
+		for (let i = 0; i < NUMBER_RULES; i++) {
+			engine.evaluate(makeEval1())
+		}
+	})
+
+	const makeEval2 = () => ({
+		valeur: 'salarié . coût total employeur',
+		contexte: {
+			'salarié . rémunération . net': 45000,
+		},
+	})
+	bench('Using the same contexte', () => {
+		engine.setSituation({})
+		for (let i = 0; i < NUMBER_RULES; i++) {
+			engine.evaluate(makeEval2())
+		}
+	})
+})
+
+run()

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
 		"@types/chai": "^4.3.6",
 		"@types/mocha": "^9.1.1",
 		"@types/sinon-chai": "^3.2.10",
+		"bun": "^1.1.10",
 		"chai": "^4.3.8",
 		"dedent-js": "1.0.1",
 		"intl": "^1.2.5",

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -80,18 +80,6 @@ export default class Engine<Name extends string = string> {
 
 	cache: Cache = emptyCache()
 
-	// The subEngines attribute is used to get an outside reference to the
-	// `contexte` intermediate calculations. The `contexte` mechanism uses
-	// `shallowCopy` to instanciate a new engine, and we want to keep a reference
-	// to it for the documentation.
-	//
-	// TODO: A better implementation would to remove the "runtime" concept of
-	// "subEngines" and instead duplicate all rules names in the scope of the
-	// `contexte` as described in
-	// https://github.com/publicodes/publicodes/discussions/92
-	subEngines: Array<Engine<Name>> = []
-	subEngineId: number | undefined
-
 	constructor(rules: RawPublicodes<Name> = {}, options: Options = {}) {
 		const strict = options.strict ?? true
 		const initialContext = {

--- a/packages/react-ui/src/RuleLink.tsx
+++ b/packages/react-ui/src/RuleLink.tsx
@@ -86,11 +86,11 @@ export function RuleLinkWithContext(
 		typeof window !== 'undefined' &&
 		new URLSearchParams(window.location.search).get('currentEngineId')
 	const currentEngineId =
-		props.useSubEngine !== false ?
-			props.currentEngineId ||
-			engine.subEngineId ||
-			(currentEngineIdFromUrl ? Number(currentEngineIdFromUrl) : undefined)
-		:	undefined
+		(props.useSubEngine !== false &&
+			(props.currentEngineId ||
+				engine.context.subEngineId ||
+				(currentEngineIdFromUrl && Number.parseInt(currentEngineIdFromUrl)))) ||
+		undefined
 	return (
 		<RuleLink
 			engine={engine}

--- a/packages/react-ui/src/mecanisms/Contexte.tsx
+++ b/packages/react-ui/src/mecanisms/Contexte.tsx
@@ -11,7 +11,7 @@ export default function Contexte({ explanation }: EvaluatedNode<'contexte'>) {
 	const engine = useEngine()
 	const contexteEngine =
 		explanation.subEngineId ?
-			engine.subEngines[explanation.subEngineId] ?? engine
+			engine.context.subEngines.get(explanation.subEngineId) ?? engine
 		:	engine
 
 	return (

--- a/packages/react-ui/src/rule/RulePage.tsx
+++ b/packages/react-ui/src/rule/RulePage.tsx
@@ -70,7 +70,7 @@ export default function RulePage({
 					<Rule
 						dottedName={utils.decodeRuleName(rulePath)}
 						subEngineId={
-							currentEngineId ? parseInt(currentEngineId) : undefined
+							currentEngineId ? parseInt(currentEngineId, 10) : undefined
 						}
 						language={language}
 						apiDocumentationUrl={apiDocumentationUrl}
@@ -116,9 +116,10 @@ function Rule({
 }: RuleProps) {
 	const baseEngine = useEngine()
 	const { References, Text } = useContext(RenderersContext)
-
-	const useSubEngine = subEngineId && baseEngine.subEngines[subEngineId]
-	const engine = useSubEngine ? baseEngine.subEngines[subEngineId] : baseEngine
+	const subEngines = baseEngine.context.subEngines
+	const useSubEngine = subEngineId && subEngines.has(subEngineId)
+	const engine =
+		useSubEngine ? (subEngines.get(subEngineId) as Engine) : baseEngine
 
 	if (!(dottedName in engine.context.parsedRules)) {
 		return <p>Cette règle est introuvable dans la base</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3884,6 +3884,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oven/bun-darwin-aarch64@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-darwin-aarch64@npm:1.1.10"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-darwin-x64-baseline@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-darwin-x64-baseline@npm:1.1.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-darwin-x64@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-darwin-x64@npm:1.1.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-linux-aarch64@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-linux-aarch64@npm:1.1.10"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-linux-x64-baseline@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-linux-x64-baseline@npm:1.1.10"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-linux-x64@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-linux-x64@npm:1.1.10"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-windows-x64-baseline@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-windows-x64-baseline@npm:1.1.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oven/bun-windows-x64@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@oven/bun-windows-x64@npm:1.1.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@philpl/buble@npm:^0.19.7":
   version: 0.19.7
   resolution: "@philpl/buble@npm:0.19.7"
@@ -7350,6 +7406,43 @@ __metadata:
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
   checksum: db021755d7ed8be048f25668fe2117620861ef6703ea2c65ed2779c9e3636d5c3b82325bd912244293959ff3ae303afa3471f6a15bf5060c103e4cc3a839749d
+  languageName: node
+  linkType: hard
+
+"bun@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "bun@npm:1.1.10"
+  dependencies:
+    "@oven/bun-darwin-aarch64": 1.1.10
+    "@oven/bun-darwin-x64": 1.1.10
+    "@oven/bun-darwin-x64-baseline": 1.1.10
+    "@oven/bun-linux-aarch64": 1.1.10
+    "@oven/bun-linux-x64": 1.1.10
+    "@oven/bun-linux-x64-baseline": 1.1.10
+    "@oven/bun-windows-x64": 1.1.10
+    "@oven/bun-windows-x64-baseline": 1.1.10
+  dependenciesMeta:
+    "@oven/bun-darwin-aarch64":
+      optional: true
+    "@oven/bun-darwin-x64":
+      optional: true
+    "@oven/bun-darwin-x64-baseline":
+      optional: true
+    "@oven/bun-linux-aarch64":
+      optional: true
+    "@oven/bun-linux-x64":
+      optional: true
+    "@oven/bun-linux-x64-baseline":
+      optional: true
+    "@oven/bun-windows-x64":
+      optional: true
+    "@oven/bun-windows-x64-baseline":
+      optional: true
+  bin:
+    bun: bin/bun.exe
+    bunx: bin/bun.exe
+  checksum: df30bac4c68b85631035d156df8e67ec7ed17402985f3255ac4c65855e58ebed3296e805b83d40851afe1c33cc4d8a816c74fba04cd77a55a2d71568f3ac639c
+  conditions: (os=darwin | os=linux | os=win32) & (cpu=arm64 | cpu=x64)
   languageName: node
   linkType: hard
 
@@ -18103,6 +18196,7 @@ __metadata:
     "@types/chai": ^4.3.6
     "@types/mocha": ^9.1.1
     "@types/sinon-chai": ^3.2.10
+    bun: ^1.1.10
     chai: ^4.3.8
     dedent-js: 1.0.1
     intl: ^1.2.5


### PR DESCRIPTION
Perf : améliore les performances du mécanisme `contexte`. 

Si plusieurs contextes sont identiques, alors ils partagent un `subEngine` pour éviter de recalculer les mêmes règles plusieurs fois.

À noter : comme le parsing se fait avant la désambiguïsation des références, on ne peut pas (encore) relier deux contextes identiques, mais avec deux résolutions de nom différentes. 

Exemple :

```
a: 
  contexte: 
    x . y: 5
x: 
  contexte: 
    y: 5
x . y :
```

Les deux contextes auront un hash différent, et ne bénéficieront pas du partage du subEngine, et donc de l'optimisation des calculs. 

TODO : 
- [ ] https://github.com/publicodes/publicodes/pull/485