### PR TITLE
Ajout des parametres min/max sur le mécanisme d'inversion numérique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,25 @@
 # Changelog
 
+## 1.4.0
+
+- Ajoute les champs `min` et `max` pour le mécanisme d'inversion numérique
+
 ## 1.3.3
+
 - Fix critical bug with `context` mecanism introduced in 1.3.2
 
 ## 1.3.2
 
 **@publicodes/core**
+
 - Fix `setSituation` with `keepPreviousSituation` option which was broken when using `context` mecanism (#487)
 - Perf: improves the performance of the `context` mechanism. If several contexts are identical, then they share a `subEngine` to avoid recalculating the same rules several times (#484)
-
 
 ## 1.3.1
 
 **@publicodes/core**
 
 - Fix `allowOrphanRules` option which was broken by 1.3.0
-
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0
 
 - Ajoute les champs `min` et `max` pour le mécanisme d'inversion numérique
+- Ajoute du champ `tolérance d'erreur` pour le mécanisme d'inversion numérique
 
 ## 1.3.3
 

--- a/packages/core/src/mecanisms/inversion.ts
+++ b/packages/core/src/mecanisms/inversion.ts
@@ -13,6 +13,7 @@ export type InversionNode = {
 		inversionCandidates: Array<ReferenceNode>
 		min: number
 		max: number
+		errorTolerance: number
 		unit?: Unit
 
 		// Explanation computed during evaluation
@@ -164,12 +165,13 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 			y2 !== undefined && y2 > goal && (y2 < y1 || y1 < goal) ? x2
 			: y1 !== undefined && y1 > goal && (y1 < y2 || y2 < goal) ? x1
 			: node.explanation.max
+		const errorTolerance = node.explanation.errorTolerance
 
 		nodeValue = uniroot(
 			test,
 			nearestBelowGoal,
 			nearestAboveGoal,
-			0.1,
+			errorTolerance,
 			maxIterations,
 			1,
 		)
@@ -219,6 +221,10 @@ export const mecanismInversion = (v, context: Context) => {
 	let avec = typeof v === 'object' && 'avec' in v ? v.avec : v
 	const min = typeof v === 'object' && 'min' in v ? v.min : -1000000
 	const max = typeof v === 'object' && 'max' in v ? v.max : 100000000
+	const errorTolerance =
+		typeof v === 'object' && "tolérance d'erreur" in v ?
+			v["tolérance d'erreur"]
+		:	0.1
 	if (v === null) {
 		throw new PublicodesError(
 			'SyntaxError',
@@ -237,6 +243,7 @@ export const mecanismInversion = (v, context: Context) => {
 			})),
 			min,
 			max,
+			errorTolerance,
 		},
 		nodeKind: 'inversion',
 	} as InversionNode

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -232,4 +232,22 @@ describe('inversions', () => {
 
 		expect(result.nodeValue).to.be.equal(undefined)
 	})
+
+	it('should handle an inversion with "tolérance d\'erreur"', () => {
+		const errorTolerance = 0.1
+		const rules = parseYaml`
+        net: brut * 50%
+        brut:
+          formule:
+            inversion numérique:
+              unité: €
+              avec:
+                - net
+              tolérance d'erreur: ${errorTolerance}
+      `
+		const result = new Engine(rules, { inversionMaxIterations: 1 })
+			.setSituation({ net: 1000 })
+			.evaluate('brut')
+		expect(result.nodeValue).to.be.closeTo(1000 * 2, errorTolerance)
+	})
 })

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -160,4 +160,76 @@ describe('inversions', () => {
 		engine.setSituation({ net: 150 }).evaluate('brut')
 		expect(engine.evaluate('assiette').nodeValue).to.be.undefined
 	})
+
+	it('should handle an inversion with min', () => {
+		const rules = parseYaml`
+        net: brut * 50%
+        brut:
+          formule:
+            inversion numérique:
+              unité: €
+              avec:
+                - net
+              min: 1500
+      `
+		const result = new Engine(rules)
+			.setSituation({ net: 1000 })
+			.evaluate('brut')
+
+		expect(result.nodeValue).to.be.equal(2000)
+	})
+
+	it('should handle an inversion with max', () => {
+		const rules = parseYaml`
+        net: brut * 50%
+        brut:
+          formule:
+            inversion numérique:
+              unité: €
+              avec:
+                - net
+              max: 2500
+      `
+		const result = new Engine(rules)
+			.setSituation({ net: 1000 })
+			.evaluate('brut')
+
+		expect(result.nodeValue).to.be.equal(2000)
+	})
+
+	it('should not succeed when result are lower than the min', () => {
+		const rules = parseYaml`
+        net: brut * 50%
+        brut:
+          formule:
+            inversion numérique:
+              unité: €
+              avec:
+                - net
+              min: 2500
+      `
+		const result = new Engine(rules)
+			.setSituation({ net: 1000 })
+			.evaluate('brut')
+
+		expect(result.nodeValue).to.be.equal(undefined)
+	})
+
+	it('should not succeed when result are greater than the max', () => {
+		const rules = parseYaml`
+        net: brut * 50%
+        brut:
+          formule:
+            inversion numérique:
+              unité: €
+              avec:
+                - net
+              max: 1500
+      `
+		const result = new Engine(rules)
+			.setSituation({ net: 1000 })
+			.evaluate('brut')
+
+		expect(result.nodeValue).to.be.equal(undefined)
+	})
 })

--- a/website-v2/src/routes/docs/mecanismes/+page.svelte.md
+++ b/website-v2/src/routes/docs/mecanismes/+page.svelte.md
@@ -617,7 +617,16 @@ L’algorithme utilisé est la [méthode de
 Brent](https://fr.wikipedia.org/wiki/M%C3%A9thode_de_Brent). L’idée générale
 est de prendre une valeur au hasard pour la variable en question, et
 d’améliorer mathématiquement le choix jusqu’à ce que les valeurs cibles
-soient toutes suffisamment proches des objectifs.
+soient toutes suffisamment proches des objectifs. La tolérance entre le choix et les valeurs cibles peut être configuré avec `tolérance d'erreur` (par défaut: `0.1`).
+
+```publicodes title="Exemple tolérance d'erreur"
+a: b + 10
+b:
+  inversion numérique:
+    avec:
+      - a
+    tolérance d'erreur: 1
+```
 
 Afin d'optimiser les performances du calcul d'inversion numérique, il est possible d'utiliser le champ `min` (par défaut: `-1000000`) et/ou `max` (par défault: `100000000`) afin de limiter à une certaine plage la valeur au hasard choisi en début de calcul.
 

--- a/website-v2/src/routes/docs/mecanismes/+page.svelte.md
+++ b/website-v2/src/routes/docs/mecanismes/+page.svelte.md
@@ -619,6 +619,18 @@ est de prendre une valeur au hasard pour la variable en question, et
 d’améliorer mathématiquement le choix jusqu’à ce que les valeurs cibles
 soient toutes suffisamment proches des objectifs.
 
+Afin d'optimiser les performances du calcul d'inversion numérique, il est possible d'utiliser le champ `min` (par défaut: `-1000000`) et/ou `max` (par défault: `100000000`) afin de limiter à une certaine plage la valeur au hasard choisi en début de calcul.
+
+```publicodes title="Exemple min/max"
+a: b + 10
+b:
+  inversion numérique:
+    avec:
+      - a
+    min: 0
+    max: 100000
+```
+
 Si on demande au moteur la valeur d’une variable qui a pour formule une
 inversion, il va vérifier qu’une des variables `avec` a bien une valeur
 (calculée ou saisie), et procéder à l’inversion décrite plus haut à partir


### PR DESCRIPTION
En rajoutant la possibilité de "borner" l'inversion numérique nous avons améliorer le temps de calcul d'environ 20%.

Il est parfois délicat de trouver un maximum, mais la seule utilisation de `min: 0` (c'est facile de savoir si une valeur doit être positive) permet déjà un gain de performance non négligeable sur nos calculs.

Par contre j'ai du mal à trouver une façon de tester réellement l'impact de min/max à travers les tests unitaires. Je suis preneur si vous avez une idée.