### PR TITLE
fix: "valeur" et "formule" du type Rule peuvent être des nombres

### DIFF
--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -15,8 +15,8 @@ import { isAccessible, nameLeaf, ruleParents } from './ruleUtils'
 import { weakCopyObj } from './utils'
 
 export type Rule = {
-	formule?: Record<string, unknown> | string
-	valeur?: Record<string, unknown> | string
+	formule?: Record<string, unknown> | string | number
+	valeur?: Record<string, unknown> | string | number
 	question?: string
 	description?: string
 	unité?: string


### PR DESCRIPTION
Sur nosgestesclimat, les "valeur" et "formule" d'un rawNode (Rule) sont parfois des nombres.

```
const engine = new Engine(rules);
const parsedRules = engine.getParsedRules();
const values = Object.values(parsedRules);

const numberValues = values.filter(
  (rule) => typeof rule.rawNode.valeur === 'number',
);
console.log(numberValues.length); // 10

const numberFormules = values.filter(
  (rule) => typeof rule.rawNode.formule === 'number',
);
console.log(numberFormules.length); // 579
```