### PR TITLE
fix(core): inversion numérique with contexte bug

### DIFF
--- a/.changeset/light-rivers-clean.md
+++ b/.changeset/light-rivers-clean.md
@@ -1,0 +1,11 @@
+---
+'publicodes': patch
+---
+
+Fix bug with contexte
+
+v1.3.2 introduced a bug when using contexte :
+- If a contexte was evaluated before and after `setSituation` with `keepPreviousSituation` on, the returned value would be the one of the first evaluation (before setSituation)
+- If a contexte was used within a `inversion numérique`, the returned value would be `undefined`
+
+This fixes it.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"format:eslint": "run lint:eslint --fix",
 		"lint": "run lint:eslint && run lint:prettier && turbo run lint --parallel",
 		"format": "run format:eslint && run format:prettier && turbo run format --parallel",
-		"dev": "turbo run dev --parallel --filter=\"website...\"",
+		"dev": "turbo run dev --filter=\"website...\"",
 		"clean": "turbo run clean --parallel && rimraf \"**/node_modules\" \"**/dist\" \"**/*.codegen.*\" \"**/.turbo\"",
 		"release": "yarn install --refresh-lockfile && run prepack && changeset publish"
 	},

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -176,6 +176,7 @@ export class Engine<RuleNames extends string = string> {
 	 */
 	resetCache() {
 		this.cache = emptyCache()
+		this.context.subEngines = new Map()
 	}
 
 	/**

--- a/packages/core/src/mecanisms/inversion.ts
+++ b/packages/core/src/mecanisms/inversion.ts
@@ -71,7 +71,6 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 			)
 		},
 	)
-
 	if (inversionGoal === undefined) {
 		return {
 			...node,
@@ -87,6 +86,7 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 			},
 		}
 	}
+
 	const evaluatedInversionGoal = inversionEngine.evaluateNode(inversionGoal)
 	let numberOfIteration = 0
 
@@ -96,6 +96,7 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 		},
 		{ keepPreviousSituation: true },
 	)
+
 	inversionEngine.cache.traversedVariablesStack =
 		this.cache.traversedVariablesStack ? [] : undefined
 
@@ -117,6 +118,7 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 			this.cache.traversedVariablesStack ? [] : undefined
 
 		lastEvaluation = inversionEngine.evaluateNode(inversionGoal)
+
 		return lastEvaluation
 	}
 

--- a/packages/core/test/mécanismes/contexte.yaml
+++ b/packages/core/test/mécanismes/contexte.yaml
@@ -91,3 +91,15 @@ deux contextes différents donnent des résultats différents:
 
   exemples:
     - valeur attendue: 3
+
+contexte et inversion fonctionnent ensemble:
+  valeur: b
+  avec:
+    a: 4 * b
+    b:
+      inversion numérique:
+        - a
+      contexte:
+        a: 8
+  exemples:
+    - valeur attendue: 2


### PR DESCRIPTION
The subengines of the different context were not cleaned on situation update.

This should fix a number of issues originated in 1.3.2

fix #560