### PR TITLE
fix(website): add missing description for npm packages

### DIFF
--- a/website/src/data/publicodes-packages.ts
+++ b/website/src/data/publicodes-packages.ts
@@ -14,12 +14,15 @@ export const publicodesPackages: readonly PublicodesPackage[] = [
     {
         npm: '@incubateur-ademe/publicodes-commun',
         maintainer: 'nos-gestes-climat',
-        users: ['ekofest', 'impact-co2']
+        users: ['ekofest', 'impact-co2'],
+        description:
+            "Ensemble de règles communes utilisées pour l'implémentation des modèles publicodes de l'incubateur de l'ADEME"
     },
     {
         npm: '@incubateur-ademe/publicodes-impact-livraison',
         maintainer: 'nos-gestes-climat',
-        users: ['impact-co2']
+        users: ['impact-co2'],
+        description: 'Un modèle Publicodes pour le simulateur Impact Livraison de Impact CO2'
     },
     {
         npm: '@socialgouv/modeles-social',
@@ -37,7 +40,8 @@ export const publicodesPackages: readonly PublicodesPackage[] = [
     },
     {
         npm: 'publicodes-evenements',
-        maintainer: 'ekofest'
+        maintainer: 'ekofest',
+        description: "Modèle du simulateur d'empreinte carbone des événements d'Ekofest"
     },
     {
         npm: 'aides-velo',
@@ -50,15 +54,20 @@ export const publicodesPackages: readonly PublicodesPackage[] = [
     },
     {
         npm: '@betagouv/france-chaleur-urbaine-publicodes',
-        maintainer: 'france-chaleur-urbaine'
-    }, {
+        maintainer: 'france-chaleur-urbaine',
+        description:
+            "Modèle Publicodes du comparateur réalisé en partenariat avec l'association AMORCE dans le cadre de l'action C3 du programme européen Heat & Cool"
+    },
+    {
         npm: 'mesaidesreno',
-        maintainer: 'mes-aides-reno'
+        maintainer: 'mes-aides-reno',
+        description: "Aides et coût d'une rénovation thermique en 2024"
     }
 ];
 
 export type PublicodesPackage = {
     npm: string;
     maintainer: string;
+    description?: string;
     users?: ProduitSlug[];
 };

--- a/website/src/lib/component/publicode-packages.svelte
+++ b/website/src/lib/component/publicode-packages.svelte
@@ -32,7 +32,7 @@
                 </strong>
                 <div class="flex-1">
                     {#if description}
-                        <p class="mt-0">{description}</p>
+                        <p class="mt-1">{description}</p>
                     {/if}
                 </div>
                 <span class=" text-sm font-light text-slate-500">

--- a/website/src/lib/model/package-with-metadata.ts
+++ b/website/src/lib/model/package-with-metadata.ts
@@ -26,7 +26,10 @@ async function fetchPackageMetadata(
 ): Promise<PublicodesPackageWithMetadata> {
     const response = await fetch(`${NPM_REGISTRY_URL}/${pkg.npm}`);
     const data = await response.json();
-    const description = data.description.startsWith('<div') ? '' : data.description;
+    const description =
+        data.description.startsWith('<div') || data.description.startsWith('> [!')
+            ? pkg.description ?? ''
+            : data.description;
     const maintener = produits.find((produit) => produit.slug === pkg.maintainer);
     if (!maintener) {
         throw new Error(`Maintener ${pkg.maintainer} not found in produits.json`);


### PR DESCRIPTION
Certaines descriptions récupérées via NPM ne sont pas dans un format propice à être affiché en baseline comme c'est le cas sur le site. Cette PR rajoute donc la possibilité de le rajouter à la main si nécessaire.