### PR TITLE
fix(core): bug when calling setSituation with keepPreviousSituation

### DIFF
--- a/.changeset/violet-coats-work.md
+++ b/.changeset/violet-coats-work.md
@@ -1,0 +1,5 @@
+---
+'publicodes': patch
+---
+
+Fix a bug with setSituation and keepPreviousSituation

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -155,7 +155,7 @@ export class Engine<RuleNames extends string = string> {
 			...initialContext,
 			...parsePublicodes(rules as RawPublicodes<RuleNames>, initialContext),
 		})
-		this.context = this.baseContext
+		this.context = copyContext(this.baseContext)
 
 		this.publicParsedRules = {} as ParsedRules<RuleNames>
 		for (const name in this.baseContext.parsedRules) {

--- a/packages/core/test/situation.test.ts
+++ b/packages/core/test/situation.test.ts
@@ -214,4 +214,14 @@ a:
 			expect(engine.evaluate('a').nodeValue).to.equal(10)
 		}
 	})
+
+	it('should allow to reset a rule when use keepPreviousSituation first', function () {
+		const engine = engineFromYaml(`
+a:
+`)
+		engine.setSituation({ a: 10 }, { keepPreviousSituation: true })
+		engine.setSituation({})
+		const missings = engine.evaluate('a').missingVariables
+		expect(missings).to.have.all.keys('a')
+	})
 })


### PR DESCRIPTION
If there were no previous situation (first call to `setSituation`), the following `setSituation` calls would not properly reset situation. 

It is fixed now.