### PR TITLE
fix: release script generated CHANGELOG

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: yarn release
+          version: yarn version
 
         env:
           GITHUB_TOKEN: ${{ secrets.SECRET_GITHUB }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"format": "run build:packages  && run eslint --fix . && prettier --write . && turbo run format --parallel",
 		"dev": "turbo run dev --filter=\"website...\"",
 		"clean": "turbo run clean --parallel && rimraf \"**/node_modules\" \"**/dist\" \"**/*.codegen.*\" \"**/.turbo\"",
-		"release": "yarn install --refresh-lockfile && run prepack && changeset publish"
+		"release": "yarn install --refresh-lockfile && run prepack && changeset publish",
+		"version": "changeset version && prettier --write '**/CHANGELOG.md'"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.5.0",


### PR DESCRIPTION
The CHANGELOG generated by the release script was failing the CI because of badly formatted markdown.

This commit runs prettier on CHANGELOG after generating it.