### PR TITLE
fix(core): fix une possibilité so that it is not breaking anymore

### DIFF
--- a/.changeset/free-emus-draw.md
+++ b/.changeset/free-emus-draw.md
@@ -1,0 +1,19 @@
+---
+'publicodes': patch
+---
+
+Fix breaking due to applicability evaluation of possibilites
+
+In the new `une possibilité` mecanism, the engine evaluates the applicability of each possibility, in order to automatically select if there is only one possibility that is applicable.
+
+This leads to difficult to debug issues rooted in cyclic evaluations not beeing handled well in the current version of the engine.
+
+This patch fixes this issue by adding a `flag` option to filter out possibilities that are not applicable. This flag is set to `false` by default.
+
+```ts
+const engine = new Engine(rules, {
+    flag: { filterNotApplicablePossibilities: true },
+})
+```
+
+This is temporary, and will be removed in the future when the engine will be able to handle cyclic evaluations.

--- a/packages/core/src/AST/index.ts
+++ b/packages/core/src/AST/index.ts
@@ -204,6 +204,9 @@ const traverseRuleNode: TraverseFunction<'rule'> = (fn, node) => {
 	for (const key in node.suggestions) {
 		copy.suggestions[key] = fn(node.suggestions[key])
 	}
+	if (copy.possibilities) {
+		copy.possibilities = fn(copy.possibilities) as any
+	}
 	copy.replacements = node.replacements.map(fn) as Array<ReplacementRule>
 	copy.explanation = {
 		ruleDisabledByItsParent: node.explanation.ruleDisabledByItsParent,
@@ -213,9 +216,6 @@ const traverseRuleNode: TraverseFunction<'rule'> = (fn, node) => {
 			:	undefined,
 		parents: node.explanation.parents.map(fn),
 		valeur: fn(node.explanation.valeur),
-	}
-	if (copy.possibilities) {
-		copy.possibilities = fn(copy.possibilities) as any
 	}
 	return copy
 }

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -1,0 +1,101 @@
+import { Logger, PublicodesExpression } from '..'
+import { type ASTNode, type EvaluatedNode } from '../AST/types'
+import { getUnitKey } from '../units'
+
+export type Cache = {
+	inversionFail?: boolean
+	_meta: {
+		evaluationRuleStack: Array<string>
+		parentRuleStack: Array<string>
+		currentContexteSituation?: string
+	}
+	/**
+	 * Every time we encounter a reference to a rule in an expression we add it
+	 * to the current Set of traversed variables. Because we evaluate the
+	 * expression graph “top to bottom” (ie. we start by the high-level goal and
+	 * recursively evaluate its dependencies), we need to handle rule
+	 * “boundaries”, so that when we “enter” in the evaluation of a dependency,
+	 * we start with a clear empty set of traversed variables. Then, when we go
+	 * back to the referencer rule, we need to add all to merge the two sets :
+	 * rules already traversed in the current expression and the one from the
+	 * reference.
+	 */
+	traversedVariablesStack?: Array<Set<string>>
+	nodes: Map<PublicodesExpression | ASTNode, EvaluatedNode>
+}
+
+export type StrictOptions = {
+	/**
+	 * If set to true, the engine will throw when the
+	 * situation contains invalid values
+	 * (rules that don't exists, or values with syntax errors).
+	 *
+	 * If set to false, it will log the error and filter the invalid values from the situation
+	 * @default true
+	 */
+	situation?: boolean
+
+	/**
+	 * If set to true, the engine will throw when parsing a rule whose parent doesn't exist
+	 * This can be set to false to parse partial rule sets (e.g. optimized ones).
+	 * @default true
+	 */
+	noOrphanRule?: boolean
+
+	/**
+	 * If set to true, the engine will throw when a cycle is detected at runtime
+	 * @default false
+	 */
+	noCycleRuntime?: boolean
+
+	/**
+	 * If set to true, the engine will throw when a rule with 'une possibilité'
+	 * is evaluated to a value that is not in the list.
+	 * @default false
+	 */
+	checkPossibleValues?: boolean
+}
+
+export type FlagOptions = {
+	/**
+	 * When true, the engine will filter out possibilities that are not applicable based on the current situation.
+	 * @default false
+	 */
+	filterNotApplicablePossibilities?: boolean
+}
+
+/**
+ * Options for the engine constructor
+ */
+export type EngineOptions = {
+	/**
+	 * Don't throw an error if the parent of a rule is not found.
+	 * This is useful to parse partial rule sets (e.g. optimized ones).
+	 * @deprecated Use the `strict: { parentRule: false }` option instead
+	 */
+	allowOrphanRules?: boolean
+	/**
+	 * Whether the engine should trigger an error when it detects an anomaly,
+	 * or whether it should simply record it and continue.
+	 *
+	 * This option can be set globally (true or false) or for specific rules ({@link StrictOptions}).
+	 *  */
+	strict?: boolean | StrictOptions
+
+	/**
+	 * The logger used to log errors and warnings (default to console).
+	 * @type {Logger}
+	 */
+	logger?: Logger
+
+	/**
+	 * getUnitKey is a function that allows to normalize the unit in the engine.
+	 * @experimental
+	 */
+	getUnitKey?: getUnitKey
+
+	/**
+	 * flag to enable new experimental features
+	 */
+	flag?: FlagOptions
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,12 @@
 import { type ASTNode, type EvaluatedNode, type NodeKind } from './AST/types'
-import { Engine, type EngineOptions, type StrictOptions } from './engine'
+import { Engine } from './engine'
 import parsePublicodes, { RawRule } from './parsePublicodes'
 import { type Rule, type RuleNode } from './rule'
-
+import {
+	type EngineOptions,
+	type StrictOptions,
+	type FlagOptions,
+} from './engine/types'
 import * as utils from './ruleUtils'
 
 export {
@@ -42,6 +46,7 @@ export {
 	type Rule,
 	type RuleNode,
 	type StrictOptions,
+	type FlagOptions,
 }
 
 export type { Possibility } from './parsePossibilité'

--- a/packages/core/src/parsePossibilité.ts
+++ b/packages/core/src/parsePossibilité.ts
@@ -1,9 +1,12 @@
 import { ASTNode, PublicodesError, Unit } from '.'
 import { parseEstNonApplicable } from './mecanisms/est-non-applicable'
+// import { defaultNode } from './evaluationUtils'
+// import { parseEstNonApplicable } from './mecanisms/est-non-applicable'
 import parse from './parse'
 import { Context } from './parsePublicodes'
 import { Rule } from './rule'
 import { weakCopyObj } from './utils'
+// import { weakCopyObj } from './utils'
 
 /**
  * Represents a single possibility value in a "une possibilité" mechanism. It can be a constant value (string or number), or a reference to an existing rule.
@@ -83,7 +86,10 @@ Les choix possibles doivent être des constantes ou des références.`,
 		return {
 			...node,
 			type: 'reference',
-			notApplicable: parseEstNonApplicable(weakCopyObj(node), context),
+			notApplicable:
+				context.flag?.filterNotApplicablePossibilities ?
+					parseEstNonApplicable(weakCopyObj(node), context)
+				:	falseNode,
 			nodeValue: node.name,
 			publicodesValue: `'${node.name}'`,
 		} as Possibility & ASTNode<'reference'>

--- a/packages/core/src/parsePublicodes.ts
+++ b/packages/core/src/parsePublicodes.ts
@@ -6,6 +6,7 @@ import Engine, {
 	StrictOptions,
 } from '.'
 import { makeASTTransformer, traverseParsedRules } from './AST'
+import { FlagOptions } from './engine/types'
 import { PublicodesError } from './error'
 import inferNodeType, { NodesTypes } from './inferNodeType'
 import { ReplacementRule, inlineReplacements } from './parseReplacement'
@@ -24,6 +25,7 @@ export type Context<RuleNames extends string = string> = {
 	referencesMaps: ReferencesMaps<RuleNames>
 	rulesReplacements: RulesReplacements<RuleNames>
 	logger: Logger
+
 	inversionMaxIterations?: number
 
 	/**
@@ -32,6 +34,7 @@ export type Context<RuleNames extends string = string> = {
 	subEngineIncrementingNumber?: number
 
 	strict: StrictOptions
+	flag: FlagOptions
 
 	// The subEngines attribute is used to get an outside reference to the
 	// `contexte` intermediate calculations. The `contexte` mechanism uses
@@ -74,6 +77,10 @@ export function createContext<RuleNames extends string>(
 		rulesReplacements: {},
 		subEngines: new Map(),
 		subEngineId: undefined,
+		flag: {
+			filterNotApplicablePossibilities: false,
+			...partialContext.flag,
+		},
 		strict: {
 			situation: true,
 			noOrphanRule: true,

--- a/packages/core/test/mecanisms.test.ts
+++ b/packages/core/test/mecanisms.test.ts
@@ -15,7 +15,11 @@ import testSuites from './mécanismes/index'
 testSuites.forEach(([suiteName, suite]) => {
 	// if (suiteName !== 'durée') return
 	describe(`Mécanisme ${suiteName}`, () => {
-		const engine = new Engine(parse(suite))
+		const engine = new Engine(parse(suite), {
+			flag: {
+				filterNotApplicablePossibilities: true,
+			},
+		})
 		Object.entries(engine.getParsedRules())
 			.filter(([, rule]) => !!rule.rawNode.exemples)
 			.forEach(([name, test]) => {

--- a/packages/core/test/unePossibilité.test.js
+++ b/packages/core/test/unePossibilité.test.js
@@ -320,13 +320,20 @@ choix:
 			})
 
 			it('filterNotApplicable removes non applicable possibilities', () => {
-				const engine = engineFromYaml(`
+				const engine = engineFromYaml(
+					`
 choix:
   une possibilité:
     - option1:
         non applicable si: oui
     - option2:
-    - option3:`)
+    - option3:`,
+					{
+						flag: {
+							filterNotApplicablePossibilities: true,
+						},
+					},
+				)
 				const possibilities = engine.getPossibilitiesFor('choix', {
 					filterNotApplicable: true,
 				})
@@ -335,11 +342,19 @@ choix:
 			})
 
 			it('filterNotApplicable keeps all possibilities when no conditions', () => {
-				const engine = engineFromYaml(`
+				const engine = engineFromYaml(
+					`
 choix:
   une possibilité:
     - option1:
-    - option2:`)
+    - option2:`,
+					{
+						flag: {
+							filterNotApplicablePossibilities: true,
+						},
+					},
+				)
+
 				const possibilities = engine.getPossibilitiesFor('choix', {
 					filterNotApplicable: true,
 				})

--- a/packages/forms/src/evaluatedFormElement.test.ts
+++ b/packages/forms/src/evaluatedFormElement.test.ts
@@ -27,11 +27,14 @@ describe('evaluateFormElement', () => {
 	})
 
 	it('should evaluate radio group', () => {
-		const engine = new Engine({
-			'mon choix': {
-				'une possibilité': ["'opt1'", "'opt2'"],
+		const engine = new Engine(
+			{
+				'mon choix': {
+					'une possibilité': ["'opt1'", "'opt2'"],
+				},
 			},
-		})
+			{ flag: { filterNotApplicablePossibilities: true } },
+		)
 
 		const result = getEvaluatedFormElement(
 			engine,
@@ -46,12 +49,19 @@ describe('evaluateFormElement', () => {
 	})
 
 	it('should handle default values and situation override', () => {
-		const engine = new Engine({
-			'mon choix': {
-				'par défaut': 12,
-				'une possibilité': [12, 42],
+		const engine = new Engine(
+			{
+				'mon choix': {
+					'par défaut': 12,
+					'une possibilité': [12, 42],
+				},
 			},
-		})
+			{
+				flag: {
+					filterNotApplicablePossibilities: true,
+				},
+			},
+		)
 		engine.setSituation({
 			'mon choix': 42,
 		})
@@ -66,20 +76,23 @@ describe('evaluateFormElement', () => {
 	})
 
 	it('should handle non applicable options', () => {
-		const engine = new Engine({
-			'mon choix': {
-				valeur: "'opt2'",
-				'une possibilité': [
-					{
-						opt1: {
-							'applicable si': 'non',
+		const engine = new Engine(
+			{
+				'mon choix': {
+					valeur: "'opt2'",
+					'une possibilité': [
+						{
+							opt1: {
+								'applicable si': 'non',
+							},
 						},
-					},
-					{ opt2: {} },
-					{ opt3: {} },
-				],
+						{ opt2: {} },
+						{ opt3: {} },
+					],
+				},
 			},
-		})
+			{ flag: { filterNotApplicablePossibilities: true } },
+		)
 
 		const result = getEvaluatedFormElement(
 			engine,

--- a/website/src/lib/component/publicodes/create-engine.ts
+++ b/website/src/lib/component/publicodes/create-engine.ts
@@ -36,6 +36,9 @@ export function createEngine(yamlRules: string): EngineAndErrors {
 					warning.push(message);
 				},
 				log: () => {}
+			},
+			flag: {
+				filterNotApplicablePossibilities: true
 			}
 		});
 		for (const rule of Object.keys(engine.getParsedRules())) {

--- a/website/src/routes/docs/manuel/une-possibilite/+page.svelte.md
+++ b/website/src/routes/docs/manuel/une-possibilite/+page.svelte.md
@@ -117,6 +117,18 @@ En utilisant des références à une règle plutôt que des constantes, vous pou
 
 ### Condition
 
+<Callout type="warning" title="Fonctionalité expérimentale">
+
+Pour des raisons de rétro-compatibilitié, la fonctionnalité suivante doit être activée explicitement avec un paramètre `flag` ([voir la doc](/docs/api/publicodes/type-aliases/EngineOptions)).
+
+```typescript
+const engine = new Engine(rules, {
+    flag: { filterNotApplicablePossibilities: true }
+});
+```
+
+</Callout>
+
 Il est possible de définir des conditions d'applicabilité pour chaque possibilité. Cela permet de restreindre les possibilités en fonction de la situation.
 
 ```publicodes title="Possibilité non applicable" selectedRuleInDoc="contrat"


### PR DESCRIPTION

Fix breaking due to applicability evaluation of possibilites

In the new `une possibilité` mecanism, the engine evaluates the applicability of each possibility, in order to automatically select if there is only one possibility that is applicable.

This leads to difficult to debug issues rooted in cyclic evaluations not beeing handled well in the current version of the engine.

This patch fixes this issue by adding a `flag` option to filter out possibilities that are not applicable. This flag is set to `false` by default.

```ts
const engine = new Engine(rules, {
    flag: { filterNotApplicablePossibilities: true },
})
```

This is temporary, and will be removed in the future when the engine will be able to handle cyclic evaluations.