### PR TITLE
feat(forms): new form metadata in publicodes rule

### DIFF
--- a/.changeset/easy-phones-watch.md
+++ b/.changeset/easy-phones-watch.md
@@ -1,0 +1,13 @@
+---
+'@publicodes/forms': minor
+---
+
+A new rule key `form` is specified for metadata used in `@publicodes/forms`. This will take the place of the `saisie` key.
+
+- BREAKING: the `saisie` key is now under the `form` key
+- BREAKING: the `orientation` key is now under the `form` key for
+  possibilities
+- It is possible to customize label and description of the input with
+  the `label` and `description` keys
+- It is possible to customize the order of questions in form with the
+  `position` key

--- a/packages/forms/src/computeNextFields.ts
+++ b/packages/forms/src/computeNextFields.ts
@@ -1,4 +1,5 @@
 import type Engine from 'publicodes'
+import { RuleWithFormMeta } from '.'
 
 /**
  * Computes the next fields that need to be asked next in a form.
@@ -27,4 +28,19 @@ export function computeNextFields<Name extends string>(
 		})
 		.map(([dottedName]) => dottedName as Name)
 	return sortedRules
+		.map(
+			(name) =>
+				[
+					name,
+					(engine.getRule(name).rawNode as RuleWithFormMeta).form?.position ??
+						0,
+				] as const,
+		)
+		.map(
+			([name, position]) => [name, position != 0 ? 1 / position : 0] as const,
+		)
+		.sort(([, a], [, b]) => {
+			return b - a
+		})
+		.map(([name]) => name)
 }

--- a/packages/forms/src/evaluatedFormElement.test.ts
+++ b/packages/forms/src/evaluatedFormElement.test.ts
@@ -126,7 +126,9 @@ describe('evaluateFormElement', () => {
 		const engine = new Engine({
 			'mon texte': {
 				valeur: "'Un long texte'",
-				saisie: 'texte long',
+				form: {
+					saisie: 'texte long',
+				},
 			},
 		})
 

--- a/packages/forms/src/formElement.test.ts
+++ b/packages/forms/src/formElement.test.ts
@@ -53,7 +53,9 @@ describe('inputDetails', function () {
 			expect(
 				inputForRule({
 					type: 'texte',
-					saisie: 'texte long',
+					form: {
+						saisie: 'texte long',
+					},
 				}),
 			).toMatchObject({
 				element: 'textarea',
@@ -75,7 +77,9 @@ describe('inputDetails', function () {
 			})
 		})
 		test('month input', function () {
-			expect(inputForRule({ type: 'date', saisie: 'mois' })).toMatchObject({
+			expect(
+				inputForRule({ type: 'date', form: { saisie: 'mois' } }),
+			).toMatchObject({
 				element: 'input',
 				type: 'month',
 			})
@@ -145,7 +149,9 @@ describe('inputDetails', function () {
 			test('menu déroulant', function () {
 				const input = inputForRule({
 					'une possibilité': [1, 2],
-					saisie: 'menu déroulant',
+					form: {
+						saisie: 'menu déroulant',
+					},
 				})
 				expect(input.element).toBe('select')
 			})
@@ -153,14 +159,18 @@ describe('inputDetails', function () {
 			test('boutons radio (horizontal if less than two element)', function () {
 				const input = inputForRule({
 					'une possibilité': [1, 2],
-					saisie: 'boutons radio',
+					form: {
+						saisie: 'boutons radio',
+					},
 				}) as InputRadio
 				expect(input.element).toBe('RadioGroup')
 				expect(input.orientation).toBe('horizontal')
 
 				const input2 = inputForRule({
 					'une possibilité': [1, 2, 3],
-					saisie: 'boutons radio',
+					form: {
+						saisie: 'boutons radio',
+					},
 				}) as InputRadio
 				expect(input2.orientation).toBe('vertical')
 			})
@@ -168,7 +178,9 @@ describe('inputDetails', function () {
 			test('carte', function () {
 				const input = inputForRule({
 					'une possibilité': [1, 2, 3, 4],
-					saisie: 'cartes',
+					form: {
+						saisie: 'cartes',
+					},
 				}) as InputRadio
 				expect(input.element).toBe('RadioGroup')
 				expect(input.style).toBe('card')
@@ -178,8 +190,8 @@ describe('inputDetails', function () {
 			test('orientation', function () {
 				const input = inputForRule({
 					'une possibilité': [1, 2],
-					saisie: {
-						style: 'boutons radio',
+					form: {
+						saisie: 'boutons radio',
 						orientation: 'vertical',
 					},
 				}) as InputRadio

--- a/packages/forms/src/formElement.ts
+++ b/packages/forms/src/formElement.ts
@@ -141,11 +141,11 @@ export function getFormElement<Name extends string>(
 		)
 	}
 
-	let saisie = rawRule.saisie
+	let saisie = rawRule.form?.saisie
 
 	const inputDetails = {
-		label: rawRule.question || rule.title,
-		description: rawRule.description,
+		label: rawRule.form?.label ?? rawRule.question ?? rule.title,
+		description: rawRule.form?.description ?? rawRule.description,
 		id: dottedName,
 	}
 
@@ -192,21 +192,23 @@ export function getFormElement<Name extends string>(
 				options,
 			}
 		}
-		const style = typeof saisie === 'string' ? saisie : saisie.style
 
 		const orientation =
-			typeof saisie === 'string' ?
-				options.length > 2 && saisie !== 'cartes' ?
-					'vertical'
-				:	'horizontal'
-			:	saisie.orientation
+			(
+				(rawRule.form &&
+					'orientation' in rawRule.form &&
+					rawRule.form.orientation) ||
+				(options.length > 2 && saisie !== 'cartes')
+			) ?
+				'vertical'
+			:	'horizontal'
 
 		return {
 			...inputDetails,
 			element: 'RadioGroup',
 			style:
-				style === 'cartes' ? 'card'
-				: style === 'boutons radio' ? 'button'
+				saisie === 'cartes' ? 'card'
+				: saisie === 'boutons radio' ? 'button'
 				: 'default',
 			orientation,
 			options,
@@ -242,10 +244,11 @@ export function getOptionList<Name extends string>(
 		}
 
 		const choiceRule = engine.getRule(choice.dottedName as Name)
+		const choiceRawRule = choiceRule.rawNode as RuleWithFormMeta
 		return {
 			value: choice.nodeValue,
-			label: choiceRule.title,
-			description: choiceRule.rawNode.description,
+			label: choiceRawRule.form?.label ?? choiceRule.title,
+			description: choiceRawRule.form?.description ?? choiceRawRule.description,
 		}
 	})
 }

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -19,34 +19,143 @@ export { convertInputValueToPublicodes } from './convertInputValueToPublicodes'
 export { updateSituationWithInputValue as updateSituationWithFormValue } from './updateSituationWithFormValue'
 
 /**
- * A Publicodes Rule with additional metadata for form input
+ * A Publicodes Rule with additional metadata for form input.
  *
- * They are used to determine the type of input to display
+ * These metadata are used to customize the user interface directly from Publicodes rules.
+ * They determine the type of input to display, labels, descriptions, and the order of questions.
+ *
+ * In YAML, these metadata are added with the `form` key:
+ *
+ * ```yaml
+ * TJM:
+ *     description: |
+ *         Tarif journalier hors taxe facturé aux clients.
+ *         Généralement entre 300 et 800 €/jour.
+ *     unité: €/jour facturé
+ *     form:
+ *         position: 1
+ *         label: Tarif journalier
+ *         description: Indiquez votre tarif journalier hors taxe
+ * ```
+ *
+ * The form metadata can customize:
+ * - Input type (checkbox, radio buttons, dropdown, text, etc.)
+ * - Labels and descriptions
+ * - Question order/priority
+ *
+ * The rule can have different input types and configurations based on its type.
  */
 export type RuleWithFormMeta = Rule & {
+	/**
+	 * The data type of the rule.
+	 * This affects what input controls are available in the form.
+	 */
 	type?: 'date' | 'nombre' | 'texte' | 'booléen'
 } & (
 		| {
+				/**
+				 * Boolean type configuration.
+				 * Used for yes/no questions or checkboxes.
+				 */
 				type?: 'booléen'
-				saisie?: 'case à cocher' | 'oui/non' // | 'interrupteur'
+				form: {
+					/**
+					 * The input style for boolean values:
+					 * - 'case à cocher': Displays a checkbox
+					 * - 'oui/non': Displays yes/no radio buttons
+					 */
+					saisie?: 'case à cocher' | 'oui/non' // | 'interrupteur'
+				}
 		  }
 		| {
+				/**
+				 * Multiple choice configuration.
+				 * Used when the rule has a set of predefined options.
+				 */
 				'une possibilité': unknown
-				saisie?:
-					| 'menu déroulant'
-					| 'boutons radio'
-					| 'cartes'
-					| {
-							style?: 'boutons radio' | 'cartes' | 'défaut'
-							orientation: 'horizontal' | 'vertical'
-					  }
+				form: {
+					/**
+					 * The input style for multiple choice questions:
+					 * - 'menu déroulant': Dropdown select menu
+					 * - 'boutons radio': Standard radio buttons
+					 * - 'cartes': Card-style selectable options
+					 *
+					 * Example in YAML:
+					 * ```yaml
+					 * une possibilité:
+					 *   - option1: Value 1
+					 *   - option2: Value 2
+					 * form:
+					 *   saisie: boutons radio
+					 * ```
+					 */
+					orientation?: 'horizontal' | 'vertical'
+					saisie?: 'menu déroulant' | 'boutons radio' | 'cartes'
+				}
 		  }
 		| {
+				/**
+				 * Text input configuration.
+				 * Used for collecting text-based information.
+				 */
 				type?: 'texte'
-				saisie?: 'texte court' | 'texte long' // | 'email' | 'url' | 'téléphone'
+				form: {
+					/**
+					 * The input style for text values:
+					 * - 'texte court': Single-line text input
+					 * - 'texte long': Multi-line text area
+					 *
+					 * Example in YAML:
+					 * ```yaml
+					 * type: texte
+					 * form:
+					 *   saisie: texte long
+					 * ```
+					 */
+					saisie?: 'texte court' | 'texte long' // | 'email' | 'url' | 'téléphone'
+				}
 		  }
 		| {
+				/**
+				 * Date input configuration.
+				 * Used for collecting date information.
+				 */
 				type?: 'date'
-				saisie?: 'année' | 'mois'
+				form: {
+					/**
+					 * The input style for date values:
+					 * - 'année': Year selection only
+					 * - 'mois': Month and year selection
+					 *
+					 * Example in YAML:
+					 * ```yaml
+					 * type: date
+					 * form:
+					 *   saisie: année
+					 * ```
+					 */
+					saisie?: 'année' | 'mois'
+				}
 		  }
-	)
+	) & {
+		form: {
+			/**
+			 * Custom label to display for this input field.
+			 * If not provided, the rule's name or description will be used.
+			 */
+			label?: string
+
+			/**
+			 * Detailed description to display below the input field.
+			 * This can provide additional context or instructions to the user.
+			 */
+			description?: string
+
+			/**
+			 * Controls the order/priority of questions.
+			 * Lower numbers will be displayed first
+			 * Negative numbers will be displayed last
+			 */
+			position?: number
+		}
+	}

--- a/website/src/routes/docs/guides/creer-un-simulateur/+page.svelte.md
+++ b/website/src/routes/docs/guides/creer-un-simulateur/+page.svelte.md
@@ -77,14 +77,12 @@ const rulesText = `
 nb jours:
   titre: Nombre de jours facturés par mois
   question: Combien de jours facturez-vous par mois en moyenne ?
-  par défaut: 15
   unité: jour facturé/mois
 
 TJM:
   titre: Tarif journalier moyen
   question: Quel est votre tarif journalier ?
   description: Tarif journalier hors taxe facturé à vos clients
-  par défaut: 500
   unité: €/jour facturé
 
 CA:
@@ -95,7 +93,7 @@ CA:
 charges fixes:
   question: Quelles sont vos charges fixes ?
   description: Incluez tous vos frais fixes - comptabilité, assurances, locaux, etc.
-  par défaut: 500
+  par défaut: 10 % * CA
   unité: €/mois
 
 rémunération brute:
@@ -314,6 +312,7 @@ const rulesText = `
 // ... règles précédentes ...
 
 type de statut:
+
   question: Quel est votre type de statut ?
   possibilités:
     - auto-entrepreneur:
@@ -487,3 +486,25 @@ Vous pouvez maintenant :
 
 - [Ajouter les explications de calculs](/docs/guides/nextjs) - Pour expliquer les résultats aux utilisateurs
 - [Créer un modèle](/docs/guides/creer-un-modele) - Pour des règles métier plus élaborées
+
+### Aller plus loin
+
+#### Personnaliser l'interface utilisateur
+
+Il est possible de personnaliser l'interface utilisateur directement depuis les règles Publicodes. Il est possible de modifier le type de saisie, les labels, ou encore l'ordre des questions.
+
+Pour cela, vous pouvez ajouter des métadonnées avec la clé `form`.
+
+```yaml
+TJM:
+    description: |
+        Tarif journalier hors taxe facturé aux clients. 
+        Généralement entre 300 et 800 €/jour.
+    unité: €/jour facturé
+    form:
+        position: 1
+        label: Tarif journalier
+        description: Indiquez votre tarif journalier hors taxe
+```
+
+> [En savoir plus sur les métadonnées de formulaire](/docs/api/forms/type-aliases/RuleWithFormMeta)


### PR DESCRIPTION
- BREAKING: the `saisie` key is now under the `form` key
- BREAKING: the `orientation` key is now under the `form` key for possibilities
- It is possible to customize label and description of the input with the `label` and `description` keys
- It is possible to customize the order of questions in form with the `position` key