### PR TITLE
fix(tools): bug when compiling possibilities with inline rules

### DIFF
--- a/.changeset/cuddly-turkeys-march.md
+++ b/.changeset/cuddly-turkeys-march.md
@@ -1,0 +1,5 @@
+---
+'@publicodes/tools': patch
+---
+
+Fix bug when compiling une possibilité with inlined rule

--- a/.changeset/poor-falcons-matter.md
+++ b/.changeset/poor-falcons-matter.md
@@ -1,0 +1,5 @@
+---
+'@publicodes/tools': patch
+---
+
+Fix bug when compiling possibilities with inline rules

--- a/packages/tools/src/serializeParsedRules.ts
+++ b/packages/tools/src/serializeParsedRules.ts
@@ -486,6 +486,29 @@ export function serializeParsedRules(
 				delete rawRules[rule][attr]
 			}
 		})
+		type Possibilités = Array<Record<string, RawRule> | string>
+		function mapPossibilités(possibilités: Possibilités) {
+			return possibilités.map((possibility) => {
+				if (!possibility || typeof possibility !== 'object') {
+					return possibility
+				}
+				return Object.keys(possibility)[0]
+			})
+		}
+		if (rawRules[rule]['une possibilité']) {
+			const possibilités = rawRules[rule]['une possibilité']
+			if (Array.isArray(possibilités)) {
+				rawRules[rule]['une possibilité'] = mapPossibilités(
+					possibilités as Possibilités,
+				)
+			} else {
+				rawRules[rule]['une possibilité'] = {
+					...possibilités,
+					// eslint-disable-next-line
+					possibilités: mapPossibilités((possibilités as any).possibilités),
+				}
+			}
+		}
 
 		rawRules[rule] = {
 			...rawRules[rule],

--- a/packages/tools/test/compilation/getModelFromSource.test.ts
+++ b/packages/tools/test/compilation/getModelFromSource.test.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path'
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { getModelFromSource } from '../../src/compilation/getModelFromSource'
 
 const testDataDir = resolve('./test/compilation/data/')

--- a/packages/tools/test/compilation/ruleTypes.test.ts
+++ b/packages/tools/test/compilation/ruleTypes.test.ts
@@ -95,6 +95,22 @@ describe('resolveRuleType > constant rules', () => {
 			},
 		})
 	})
+	it('enum (une possibilité de règles inlined)', () => {
+		const rawRules = {
+			rule: {
+				'une possibilité': [{ 'rule 1': 1 }, { 'rule 2': 2 }],
+			},
+		}
+		expect(getTypes(rawRules)).toEqual({
+			rule: {
+				type: 'enum',
+				options: ['rule 1', 'rule 2'],
+				isNullable: false,
+			},
+			'rule . rule 1': { type: 'number', isNullable: false },
+			'rule . rule 2': { type: 'number', isNullable: false },
+		})
+	})
 })
 
 // TODO: Add tests for the following cases:

--- a/packages/tools/test/serializeParsedRules.test.ts
+++ b/packages/tools/test/serializeParsedRules.test.ts
@@ -931,4 +931,26 @@ describe('More complexe cases', () => {
 		)
 		expect(serializedRules).toStrictEqual(rules)
 	})
+
+	it('should correctly serialize [une possibilité] with a rule as a value', () => {
+		const rules = {
+			'chauffage collectif': {
+				question: 'Votre chauffage est-il collectif ou individuel ?',
+				'par défaut': "'collectif'",
+				'une possibilité': [{ collectif: null }, { individuel: null }],
+			},
+		}
+		const serializedRules = serializeParsedRules(
+			new Engine(rules).getParsedRules(),
+		)
+		expect(serializedRules).toStrictEqual({
+			'chauffage collectif': {
+				question: 'Votre chauffage est-il collectif ou individuel ?',
+				'par défaut': "'collectif'",
+				'une possibilité': ['collectif', 'individuel'],
+			},
+			'chauffage collectif . collectif': null,
+			'chauffage collectif . individuel': null,
+		})
+	})
 })


### PR DESCRIPTION
Inline rules were added explicitely in the compiled output, which result in an error about already defined rules