### PR TITLE
feat(react-ui): add "rulesToHide" option

### DIFF
--- a/packages/react-ui/src/contexts.tsx
+++ b/packages/react-ui/src/contexts.tsx
@@ -81,3 +81,7 @@ export const DottedNameContext = createContext<string | undefined>(undefined)
 export const EngineContext = createContext<Engine<string> | undefined>(
 	undefined,
 )
+
+export const RulesToHideContext = createContext<Array<string> | undefined>(
+	undefined,
+)

--- a/packages/react-ui/src/hooks.ts
+++ b/packages/react-ui/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { EngineContext } from './contexts'
+import { EngineContext, RulesToHideContext } from './contexts'
 
 export const useEngine = () => {
 	const engine = useContext(EngineContext)
@@ -8,4 +8,16 @@ export const useEngine = () => {
 	}
 
 	return engine
+}
+
+export const useHideValue = (dottedName: string | undefined) => {
+	if (!dottedName) {
+		return false
+	}
+	const rulesToHide = useContext(RulesToHideContext)
+	if (!rulesToHide) {
+		return false
+	}
+
+	return rulesToHide.includes(dottedName)
 }

--- a/packages/react-ui/src/mecanisms/Reference.tsx
+++ b/packages/react-ui/src/mecanisms/Reference.tsx
@@ -5,6 +5,7 @@ import Explanation from '../Explanation'
 import { RuleLinkWithContext } from '../RuleLink'
 import { EngineContext } from '../contexts'
 import { NodeValueLeaf } from './common/NodeValueLeaf'
+import { useHideValue } from '../hooks'
 
 // Un élément du graphe de calcul qui a une valeur interprétée (à afficher)
 export default function Reference(
@@ -15,6 +16,9 @@ export default function Reference(
 	const engine = useContext(EngineContext)
 	const { dottedName, nodeValue, unit } = node
 	const rule = engine?.context.parsedRules[node.dottedName]
+
+	const hideValue = useHideValue(dottedName)
+
 	if (!rule) {
 		throw new Error(`Unknown rule: ${dottedName}`)
 	}
@@ -28,6 +32,7 @@ export default function Reference(
 	) {
 		return <Explanation node={engine?.evaluate(rule)} />
 	}
+
 	return (
 		<div
 			style={{
@@ -76,7 +81,7 @@ export default function Reference(
 					)}
 
 					{nodeValue !== undefined && (
-						<NodeValueLeaf data={nodeValue} unit={unit} />
+						<NodeValueLeaf data={nodeValue} unit={unit} hideValue={hideValue} />
 					)}
 				</div>
 			</div>{' '}

--- a/packages/react-ui/src/mecanisms/common/NodeValueLeaf.tsx
+++ b/packages/react-ui/src/mecanisms/common/NodeValueLeaf.tsx
@@ -5,9 +5,10 @@ type Props = {
 	data: Evaluation
 	unit: Unit | undefined
 	fullPrecision?: boolean
+	hideValue?: boolean
 }
 
-export const NodeValueLeaf = ({ data, unit }: Props) => {
+export const NodeValueLeaf = ({ data, unit, hideValue }: Props) => {
 	return (
 		<StyledNodeValuePointer
 			className="node-value-pointer"
@@ -16,6 +17,8 @@ export const NodeValueLeaf = ({ data, unit }: Props) => {
 		>
 			{data === null ?
 				<span aria-hidden>-</span>
+			: hideValue ?
+				"masquée par l'intégrateur"
 			:	formatValue({ nodeValue: data, unit })}
 		</StyledNodeValuePointer>
 	)

--- a/packages/react-ui/src/rule/RulePage.tsx
+++ b/packages/react-ui/src/rule/RulePage.tsx
@@ -14,10 +14,11 @@ import {
 	DottedNameContext,
 	EngineContext,
 	RenderersContext,
+	RulesToHideContext,
 	SupportedRenderers,
 } from '../contexts'
 import Explanation from '../Explanation'
-import { useEngine } from '../hooks'
+import { useEngine, useHideValue } from '../hooks'
 import { RuleLinkWithContext } from '../RuleLink'
 import { getPrecision } from '../utils'
 import { DeveloperAccordion } from './DeveloperAccordion'
@@ -46,6 +47,7 @@ export default function RulePage({
 	mobileMenuPortalId,
 	openNavButtonPortalId,
 	showDevSection = true,
+	rulesToHide,
 }: {
 	/**
 	 * The base path on which the documentation will be mounted. For example, if it is /documentation, the URL of the rule remuneration.primes will be /documentation/remuneration/primes.
@@ -97,6 +99,10 @@ export default function RulePage({
 	 * @default true
 	 */
 	showDevSection?: boolean
+	/**
+	 * The dotted name we want the value to be hidden.
+	 */
+	rulesToHide?: Array<string>
 }) {
 	const currentEngineId =
 		typeof window !== 'undefined' &&
@@ -113,20 +119,22 @@ export default function RulePage({
 		<EngineContext.Provider value={engine}>
 			<BasepathContext.Provider value={documentationPath}>
 				<RenderersContext.Provider value={defaultRenderers(renderers)}>
-					<Rule
-						dottedName={utils.decodeRuleName(rulePath)}
-						subEngineId={
-							currentEngineId ? parseInt(currentEngineId, 10) : undefined
-						}
-						language={language}
-						apiDocumentationUrl={apiDocumentationUrl}
-						apiEvaluateUrl={apiEvaluateUrl}
-						npmPackage={npmPackage}
-						mobileMenuPortalId={mobileMenuPortalId}
-						openNavButtonPortalId={openNavButtonPortalId}
-						showDevSection={showDevSection}
-						searchBar={searchBar}
-					/>
+					<RulesToHideContext.Provider value={rulesToHide}>
+						<Rule
+							dottedName={utils.decodeRuleName(rulePath)}
+							subEngineId={
+								currentEngineId ? parseInt(currentEngineId, 10) : undefined
+							}
+							language={language}
+							apiDocumentationUrl={apiDocumentationUrl}
+							apiEvaluateUrl={apiEvaluateUrl}
+							npmPackage={npmPackage}
+							mobileMenuPortalId={mobileMenuPortalId}
+							openNavButtonPortalId={openNavButtonPortalId}
+							showDevSection={showDevSection}
+							searchBar={searchBar}
+						/>
+					</RulesToHideContext.Provider>
 				</RenderersContext.Provider>
 			</BasepathContext.Provider>
 		</EngineContext.Provider>
@@ -186,6 +194,9 @@ function Rule({
 		references: rule.rawNode.références,
 		dottedName: rule.dottedName,
 	})
+
+	const hideValue = useHideValue(dottedName)
+
 	return (
 		<EngineContext.Provider value={engine}>
 			<Container id="documentation-rule-root">
@@ -204,7 +215,9 @@ function Rule({
 
 						<p style={{ fontSize: '1.25rem', lineHeight: '2rem' }}>
 							Valeur :{' '}
-							{formatValue(rule, { language, precision: getPrecision(rule) })}
+							{hideValue ?
+								"masquée par l'intégrateur"
+							:	formatValue(rule, { language, precision: getPrecision(rule) })}
 							{rule.nodeValue === undefined && rule.unit && (
 								<>
 									<br />
@@ -215,6 +228,7 @@ function Rule({
 
 						{ruleDisabledByItsParent && nullableParent && (
 							<>
+								@
 								<blockquote>
 									Cette règle est <strong>non applicable</strong> car elle
 									appartient à l’espace de nom :{' '}


### PR DESCRIPTION
Objectif: permettre de cacher certaines valeurs pour des raisons de confidentialité. Le caractère privé de la variable ne suffisait pas / ne fonctionnait pas pour moi. Et je ne voulais pas me contraindre sur les restrictions d'utilisation de variables privées.

<img width="1746" height="924" alt="image" src="https://github.com/user-attachments/assets/6cb9fe08-62dd-430c-8dcc-4834685eaa03" />

Avec les variables privées si on omet le pb de l'accès "pas partout", la page n'est pas accessible mais le chiffre visible

<img width="1288" height="512" alt="image" src="https://github.com/user-attachments/assets/3d024dc1-99b2-487c-9f70-070a93b0f695" />

Preneur de os retours, sur l'idée, l'implé et le nom à afficher si masqué :)
