### PR TITLE
chore: do not warn about missing types when default_to_public is true

### DIFF
--- a/packages/compiler/lib/compiler.ml
+++ b/packages/compiler/lib/compiler.ml
@@ -35,6 +35,7 @@ let compile ~input_files ~output_type ~default_to_public =
   let* outputs =
     Dependency_graph.cycle_check eval_tree
     >>= Dependency_graph.extract_outputs ~ast ~eval_tree
+          ~warn_types:(not default_to_public)
   in
   let output_str =
     match output_type with

--- a/packages/compiler/lib/dependency_graph/extract_outputs.ml
+++ b/packages/compiler/lib/dependency_graph/extract_outputs.ml
@@ -12,7 +12,7 @@ let remove_duplicates (a : 'a list) : 'a list =
   Set.to_list @@ Set.Poly.of_list a
 
 let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
-    (graph : G.t) : Model_outputs.t Output.t =
+    ~(warn_types : bool) (graph : G.t) : Model_outputs.t Output.t =
   let transitive_dependencies =
     Oper.transitive_closure ~reflexive:false graph
   in
@@ -86,4 +86,4 @@ let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
         | Some _ ->
             None )
   in
-  return ~logs:warnings outputs
+  if warn_types then return ~logs:warnings outputs else return outputs

--- a/packages/compiler/lib/dependency_graph/extract_outputs.mli
+++ b/packages/compiler/lib/dependency_graph/extract_outputs.mli
@@ -4,6 +4,7 @@ open Shared
 val extract_outputs :
      ast:'a Shared_ast.t
   -> eval_tree:Hashed_tree.t
+  -> warn_types:bool
   -> Rule_graph.G.t
   -> Model_outputs.t Output.t
 (** Extracts the public outputs of a model from its AST and dependency graph.


### PR DESCRIPTION
In this situation, some internal would lack a type, and it is okay and expected. Let's not warn in this situation.

Change-Id: Ic42acf10799d7e725d8a54873461f1926a6a6964