### PR TITLE
import feature (and related minor commits)

### DIFF
--- a/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
+++ b/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
@@ -1,0 +1,23 @@
+open Ppxlib
+
+let expand ~ctxt env_var =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  match Sys.getenv env_var with
+  | value ->
+      let ident = Longident.parse "Some" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      let value = Ast_builder.Default.estring ~loc value in
+      Ast_builder.Default.pexp_construct ~loc loc_ident (Some value)
+  | exception Not_found ->
+      let ident = Longident.parse "None" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      Ast_builder.Default.pexp_construct ~loc loc_ident None
+
+let my_extension =
+  Extension.V3.declare "comptime_env_opt" Extension.Context.expression
+    Ast_pattern.(single_expr_payload (estring __))
+    expand
+
+let rule = Ppxlib.Context_free.Rule.extension my_extension
+
+let () = Driver.register_transformation ~rules:[rule] "comptime_env_opt"

--- a/packages/compiler/lib/ppx_comptime_env/dune
+++ b/packages/compiler/lib/ppx_comptime_env/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_comptime_env)
+ (public_name publicodes.ppx_comptime_env)
+ (kind ppx_rewriter)
+ (libraries ppxlib))

--- a/packages/compiler/lib/utils/dune
+++ b/packages/compiler/lib/utils/dune
@@ -3,5 +3,6 @@
  (public_name publicodes.utils)
  (libraries base stdune ppx_deriving jingoo fpath)
  (modules :standard)
+ (preprocessor_deps (env_var PUBLICODESPATH))
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare)))
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare ppx_comptime_env)))

--- a/packages/compiler/lib/utils/file.ml
+++ b/packages/compiler/lib/utils/file.ml
@@ -118,8 +118,12 @@ let find_package current_package path =
       match Stdlib.Sys.getenv_opt "PUBLICODESPATH" with
       | Some value ->
           Ok value
-      | None ->
-          Error Absent_env
+      | None -> (
+        match [%comptime_env_opt "PUBLICODESPATH"] with
+        | Some value ->
+            Ok value
+        | None ->
+            Error Absent_env )
     in
     let values =
       String.split value ~on:':'


### PR DESCRIPTION
feat: support for the "importer" mecanism

This implement an import feature, with a new mecanism "importer". The
expanded rules are namespaced similarly to "avec". The imported rules
are never re-exported, and the public is then used to allow cross-module
references.

This can take multiple forms:

	# to import a module
	importer: foo

	# a more verbose form
	importer:
	  module: foo

	# to import a module from a different package
	importer:
	  module: foo
	  package: bar

The "bar" package is determined using the environment variable
PUBLICODESPATH, splitted on ":". Each part is a directory root to find
the matching package. Not specifying a package means the module is
looked for in the current package.

All path arguments are validated, and the format is restricted to avoid
leaving the expected directory. This also gives better hints when an
invalid path is given.

Importing modules starting with "./" will cause a relative import. The
dot part is expanded with the current module path, meaning the imported
module will be looked for relatively to the current module directory
path.

Similarly to the "./" module path prefix, we also support a "./" prefix
for PUBLICODESPATH parts. When this prefix is present, we will be
looking for the vendor package from the package directory, instead of
pwd. This allow us to support the nested node_modules strategy. Contrary
to hoisted or shallow strategies, nested is structured this way:

	node_modules/
	  package a/
	    node_modules/
	      package b/

To cover all use cases, we can use "./node_modules:node_modules" as
PUBLICODESPATH.

We now track crawled module ids to detect circular imports, and
cross-module reference. This refactorize a bit how we pass
current_rule_name, to limit the number of argument we have to pass
arround.

The node id are now generated using also the rule name to avoid clash
on successive imports of the same modules. Because the id does not come
exclusively from the position anymore, we move it to the Shared module.

The "config" and "init" compile sub-commands has been dropped, because
now the config file feels obsolete, as this simplify the compiler
API to a single folder, as a module unit.

The "module" and "package" value validation has beed dependency
inverted, so that the gathering function only checks that arguments are
valid Fpaths. This allow the compiler to gather files from non-valid
values, as relative paths as "./foo", or absolute paths as /foo.