### PR TITLE
feat: separate outputs and their parameters in the generated Javascript

### DIFF
--- a/packages/compiler/lib/dependency_graph/checks.ml
+++ b/packages/compiler/lib/dependency_graph/checks.ml
@@ -55,8 +55,9 @@ let illegal_check (ast : 'a Shared_ast.t) (graph : Rule_graph.t) : Log.t list =
   Rule_graph.fold_edges_e log_illegal graph []
 
 let checks ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t) :
-    Rule_graph.t Output.t =
-  let graph = Rule_graph.mk eval_tree in
-  let cycle_logs = cycle_check eval_tree graph in
-  let access_logs = illegal_check ast graph in
-  return ~logs:(cycle_logs @ access_logs) graph
+    (Rule_graph.t * Rule_graph.t) Output.t =
+  let dep_graph = Rule_graph.mk_depend eval_tree in
+  let cont_graph = Rule_graph.mk_context eval_tree in
+  let cycle_logs = cycle_check eval_tree dep_graph in
+  let access_logs = illegal_check ast dep_graph in
+  return ~logs:(cycle_logs @ access_logs) (dep_graph, cont_graph)

--- a/packages/compiler/lib/dependency_graph/checks.ml
+++ b/packages/compiler/lib/dependency_graph/checks.ml
@@ -54,10 +54,55 @@ let illegal_check (ast : 'a Shared_ast.t) (graph : Rule_graph.t) : Log.t list =
   in
   Rule_graph.fold_edges_e log_illegal graph []
 
+let unused_context_check (tree : 'a Eval_tree.t) (dep_graph : Rule_graph.t)
+    (cont_graph : Rule_graph.t) : Log.t list =
+  let rec are_used ctx rules_to_check =
+    match rules_to_check with
+    | [] ->
+        false
+    | from :: rest ->
+        let ctxs = Rule_graph.succ cont_graph from in
+        let deps = Rule_graph.succ dep_graph from in
+        if List.exists ctxs ~f:(Rule_name.equal ctx) then
+          (* the context is override here *)
+          false
+        else if List.exists deps ~f:(Rule_name.equal ctx) then
+          (* the context is actually used here *)
+          true
+        else are_used ctx (rest @ deps)
+  in
+  let log_unused from acc =
+    let unused_ctxs =
+      let deps = Rule_graph.succ dep_graph from in
+      (* we filter out contexts immediately used *)
+      let ctxs =
+        Rule_graph.succ cont_graph from
+        |> List.filter ~f:(fun ctx ->
+            List.exists deps ~f:(Rule_name.equal ctx) |> not )
+      in
+      List.filter ctxs ~f:(fun ctx -> not (are_used ctx deps))
+    in
+    if List.is_empty unused_ctxs then acc
+    else
+      let pos = get_pos tree from in
+      let code, message = Err.unused_context in
+      let unused_ctxs =
+        List.map unused_ctxs ~f:Rule_name.show |> String.concat ~sep:"\n- "
+      in
+      Log.error ~pos ~kind:`Syntax ~code message
+        ~hints:
+          [ Stdlib.Format.asprintf "ces contextes ne sont pas utilisés :\n- %s"
+              unused_ctxs ]
+      :: acc
+  in
+  Rule_graph.fold_vertex log_unused dep_graph []
+
 let checks ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t) :
     (Rule_graph.t * Rule_graph.t) Output.t =
   let dep_graph = Rule_graph.mk_depend eval_tree in
   let cont_graph = Rule_graph.mk_context eval_tree in
   let cycle_logs = cycle_check eval_tree dep_graph in
   let access_logs = illegal_check ast dep_graph in
-  return ~logs:(cycle_logs @ access_logs) (dep_graph, cont_graph)
+  let context_logs = unused_context_check eval_tree dep_graph cont_graph in
+  let logs = cycle_logs @ access_logs @ context_logs in
+  return ~logs (dep_graph, cont_graph)

--- a/packages/compiler/lib/dependency_graph/extract_outputs.ml
+++ b/packages/compiler/lib/dependency_graph/extract_outputs.ml
@@ -12,20 +12,34 @@ let remove_duplicates (a : 'a list) : 'a list =
   Set.to_list @@ Set.Poly.of_list a
 
 let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
-    ~(warn_types : bool) (graph : G.t) : Model_outputs.t Output.t =
-  let transitive_dependencies =
-    Oper.transitive_closure ~reflexive:false graph
-  in
+    ~(warn_types : bool) ((dep_graph, cont_graph) : G.t * G.t) :
+    Model_outputs.t Output.t =
   (* Add self-dependencies for rules without value *)
   List.iter ast ~f:(fun rule_def ->
       let rule_name = Pos.value rule_def.name in
       if not (Shared_ast.has_value rule_def) then
-        G.add_edge transitive_dependencies rule_name rule_name ) ;
+        G.add_edge dep_graph rule_name rule_name ) ;
+  (* Crawl the dependency graph from a starting vertex, accumulate the context
+    rules, and chop edges targeting them. *)
+  let rec chop_contexts ?(acc = []) graph from =
+    let acc = acc @ Rule_graph.succ cont_graph from in
+    List.iter acc ~f:(fun target -> Rule_graph.remove_edge graph from target) ;
+    (* filter out self references *)
+    Rule_graph.succ graph from
+    |> List.filter ~f:(fun to_ -> Rule_name.equal from to_ |> not)
+    |> List.iter ~f:(chop_contexts ~acc graph)
+  in
+  let transitive_dependencies from =
+    let graph = Rule_graph.copy dep_graph in
+    chop_contexts graph from ;
+    Oper.transitive_closure ~reflexive:false graph
+  in
   (* Extracts the parameters (rules without values) that a given rule depends on.
 
       @param rule_name The name of the rule to extract parameters for
       @return A tuple containing the rule name and its list of parameter dependencies *)
   let extract_parameters rule_name =
+    let transitive_dependencies = transitive_dependencies rule_name in
     let successor_rules = G.succ transitive_dependencies rule_name in
     let parameter_rules =
       List.filter successor_rules ~f:(fun dependent_rule_name ->

--- a/packages/compiler/lib/dependency_graph/extract_outputs.ml
+++ b/packages/compiler/lib/dependency_graph/extract_outputs.ml
@@ -53,8 +53,15 @@ let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
     in
     (rule_name, remove_duplicates parameter_rules)
   in
+  let wrap_meta ~is_output (rule_name, parameters) =
+    { rule_name
+    ; parameters
+    ; typ= (Eval_tree.get_meta eval_tree rule_name).typ
+    ; meta= (Shared_ast.find rule_name ast).meta
+    ; is_output }
+  in
   (* Extract the parameter list for each output rule *)
-  let outputs =
+  let output_parameters =
     List.filter_map ast ~f:(fun rule_def ->
         let rule_name = Pos.value rule_def.name in
         if
@@ -63,24 +70,16 @@ let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
         then Some (extract_parameters rule_name)
         else None )
   in
-  (* Parameters are also outputs of the model as they can be evaluated independently *)
-  let parameters = remove_duplicates @@ List.concat_map ~f:snd outputs in
-  let outputs =
-    remove_duplicates (outputs @ List.map parameters ~f:extract_parameters)
+  let outputs = List.map ~f:(wrap_meta ~is_output:true) output_parameters in
+  let parameters =
+    let dedup = remove_duplicates @@ List.concat_map ~f:snd output_parameters in
+    List.map ~f:extract_parameters dedup
+    |> List.map ~f:(wrap_meta ~is_output:false)
   in
-  (* Add metadata to outputs *)
-  let outputs : t =
-    List.map
-      ~f:(fun (rule_name, parameters) ->
-        { rule_name
-        ; parameters
-        ; typ= (Eval_tree.get_meta eval_tree rule_name).typ
-        ; meta= (Shared_ast.find rule_name ast).meta } )
-      outputs
-  in
-  (* Generate warnings for outputs missing type information *)
+  let rules = parameters @ outputs in
+  (* Generate warnings for missing type information *)
   let warnings =
-    List.filter_map outputs ~f:(fun {rule_name; typ; _} ->
+    List.filter_map rules ~f:(fun {rule_name; typ; _} ->
         match typ with
         | None ->
             let code, message = Err.missing_output_type in
@@ -102,4 +101,4 @@ let extract_outputs ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t)
         | Some _ ->
             None )
   in
-  if warn_types then return ~logs:warnings outputs else return outputs
+  if warn_types then return ~logs:warnings rules else return outputs

--- a/packages/compiler/lib/dependency_graph/extract_outputs.mli
+++ b/packages/compiler/lib/dependency_graph/extract_outputs.mli
@@ -5,7 +5,7 @@ val extract_outputs :
      ast:'a Shared_ast.t
   -> eval_tree:Hashed_tree.t
   -> warn_types:bool
-  -> Rule_graph.G.t
+  -> Rule_graph.G.t * Rule_graph.G.t
   -> Model_outputs.t Output.t
 (** Extracts the public outputs of a model from its AST and dependency graph.
 

--- a/packages/compiler/lib/dependency_graph/rule_graph.ml
+++ b/packages/compiler/lib/dependency_graph/rule_graph.ml
@@ -40,7 +40,7 @@ module G =
   Graph.Imperative.Digraph.ConcreteBidirectionalLabeled (Rule_vertex) (Ref_edge)
 include G
 
-let mk (ast : 'a Eval_tree.t) : G.t =
+let mk_depend (ast : 'a Eval_tree.t) : G.t =
   (* Create a new empty graph *)
   let graph = G.create () in
   let rec find_references ({pos; value; _} : 'a Eval_tree.value) :
@@ -76,6 +76,31 @@ let mk (ast : 'a Eval_tree.t) : G.t =
         (* Add the referenced rule vertex if it doesn't exist *)
         G.add_vertex graph referenced_rule ;
         (* Add an edge from the rule to the referenced rule, labeled with the reference position *)
+        let edge = (current_rule, Pos.pos ref_name, referenced_rule) in
+        G.add_edge_e graph edge )
+    (* Add edges for each context *)
+  in
+  (* Process all rules in the AST *)
+  Hashtbl.iteri ast ~f:(fun ~key:rule_name ~data:rule_def ->
+      add_rule_dependencies rule_name rule_def ) ;
+  graph
+
+let mk_context (ast : 'a Eval_tree.t) : G.t =
+  let graph = G.create () in
+  let list_contexts ({value; _} : 'a Eval_tree.value) : Rule_name.t Pos.t list =
+    match value with
+    | Set_context {context; _} ->
+        List.map context ~f:(fun (key, _) -> key)
+    | _ ->
+        []
+  in
+  (* Add vertices and edges to the graph *)
+  let add_rule_dependencies (current_rule : Rule_name.t) computation =
+    G.add_vertex graph current_rule ;
+    let conts = list_contexts computation in
+    List.iter conts ~f:(fun ref_name ->
+        let referenced_rule = Pos.value ref_name in
+        G.add_vertex graph referenced_rule ;
         let edge = (current_rule, Pos.pos ref_name, referenced_rule) in
         G.add_edge_e graph edge )
   in

--- a/packages/compiler/lib/hashed_tree/templates/template.js.jinja
+++ b/packages/compiler/lib/hashed_tree/templates/template.js.jinja
@@ -233,4 +233,20 @@ const rules = {
   {%- endfor %}
 }
 
+export const parameters = {
+  {%- for out in outputs %}
+  {%- if !out.is_output %}
+  '{{ fmt_esc(out.rule_name) }}': rules['{{ fmt_esc(out.rule_name) }}'],
+  {%- endif %}
+  {%- endfor %}
+}
+
+export const outputs = {
+  {%- for out in outputs %}
+  {%- if out.is_output %}
+  '{{ fmt_esc(out.rule_name) }}': rules['{{ fmt_esc(out.rule_name) }}'],
+  {%- endif %}
+  {%- endfor %}
+}
+
 export default rules;

--- a/packages/compiler/lib/hashed_tree/to_string.ml
+++ b/packages/compiler/lib/hashed_tree/to_string.ml
@@ -236,7 +236,8 @@ let from_rules hashed_tree =
            ; ("rule_name", rule_name)
            ; ("rule_node", rule_node) ] ) )
 
-let from_output hashed_tree Model_outputs.{rule_name; parameters; meta; _} =
+let from_output hashed_tree
+    Model_outputs.{rule_name; parameters; meta; is_output; _} =
   let rule_type = from_rule_type hashed_tree rule_name in
   let title =
     find_title meta |> function None -> Tnull | Some str -> Tstr str
@@ -265,6 +266,7 @@ let from_output hashed_tree Model_outputs.{rule_name; parameters; meta; _} =
     ; ("return_type", return_type)
     ; ("metas", metas)
     ; ("unit", unit)
+    ; ("is_output", Tbool is_output)
     ; ("params", params) ]
 
 let from_outputs hashed_tree outputs =

--- a/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
+++ b/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
@@ -1,0 +1,23 @@
+open Ppxlib
+
+let expand ~ctxt env_var =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  match Sys.getenv env_var with
+  | value ->
+      let ident = Longident.parse "Some" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      let value = Ast_builder.Default.estring ~loc value in
+      Ast_builder.Default.pexp_construct ~loc loc_ident (Some value)
+  | exception Not_found ->
+      let ident = Longident.parse "None" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      Ast_builder.Default.pexp_construct ~loc loc_ident None
+
+let my_extension =
+  Extension.V3.declare "comptime_env_opt" Extension.Context.expression
+    Ast_pattern.(single_expr_payload (estring __))
+    expand
+
+let rule = Ppxlib.Context_free.Rule.extension my_extension
+
+let () = Driver.register_transformation ~rules:[rule] "comptime_env_opt"

--- a/packages/compiler/lib/ppx_comptime_env/dune
+++ b/packages/compiler/lib/ppx_comptime_env/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_comptime_env)
+ (public_name publicodes.ppx_comptime_env)
+ (kind ppx_rewriter)
+ (libraries ppxlib))

--- a/packages/compiler/lib/resolver/resolver.ml
+++ b/packages/compiler/lib/resolver/resolver.ml
@@ -23,6 +23,32 @@ let check_orphan_rules ~rule_names ast =
   in
   List.filter_map ast ~f:warn_if_orphan
 
+let check_duplicate_rules ast =
+  let duplicate_logs name rules =
+    let labels =
+      List.map rules ~f:(fun rule ->
+          let pos = Pos.pos rule.name in
+          Pos.mk ~pos "définie ici" )
+    in
+    let code, message = Err.duplicate_rule in
+    Log.error message ~code ~labels ~kind:`Syntax
+      ~hints:
+        [ Stdlib.Format.asprintf "La règle `%a` est définie plusieurs fois"
+            Rule_name.pp name ]
+  in
+  let warn_if_duplicate rule_name =
+    let matching_defs =
+      List.filter ast ~f:(function rule ->
+          Rule_name.equal (Pos.value rule.name) rule_name )
+    in
+    if List.length matching_defs > 1 then
+      Some (duplicate_logs rule_name matching_defs)
+    else None
+  in
+  List.map ast ~f:(function rule -> Pos.value rule.name)
+  |> List.stable_dedup ~compare:Rule_name.compare
+  |> List.filter_map ~f:warn_if_duplicate
+
 let resolve_rule ~rule_names rule =
   let context_rule = Pos.value rule.name in
   let resolve_ref ~pos ref =
@@ -189,9 +215,11 @@ let to_resolved_ast ast =
       (List.map ast ~f:(fun rule -> Pos.value rule.name))
   in
   let orphan_logs = check_orphan_rules ~rule_names ast in
+  let duplicate_logs = check_duplicate_rules ast in
   let+ ast =
     ast
     |> List.map ~f:(resolve_rule ~rule_names)
-    |> all_keep_logs |> add_logs ~logs:orphan_logs
+    |> all_keep_logs
+    |> add_logs ~logs:(orphan_logs @ duplicate_logs)
   in
   ast

--- a/packages/compiler/lib/shared/model_outputs.ml
+++ b/packages/compiler/lib/shared/model_outputs.ml
@@ -1,16 +1,8 @@
-(** Represents a model output rule with its metadata and dependencies.
-
-    An output rule is a rule that can be evaluated and is part of the public API
-    of the model. It contains:
-    - [rule_name]: The name of the rule
-    - [parameters]: List of parameter rules that this output depends on
-    - [meta]: Metadata associated with the rule
-    - [typ]: The type of the rule (optional) *)
 type model_output =
   { rule_name: Rule_name.t
   ; parameters: Rule_name.t list
   ; meta: Shared_ast.rule_meta list
+  ; is_output: bool
   ; typ: Typ.t option }
 
-(** A list of model outputs representing all the public API of a model. *)
 type t = model_output list

--- a/packages/compiler/lib/shared/model_outputs.mli
+++ b/packages/compiler/lib/shared/model_outputs.mli
@@ -1,0 +1,18 @@
+(** Represents a model output rule with its metadata and dependencies.
+
+    An output rule is a rule that can be evaluated and is part of the public
+    API of the model. It contains:
+    - [rule_name]: The name of the rule
+    - [parameters]: List of parameter rules that this output depends on
+    - [meta]: Metadata associated with the rule
+    - [kind]: The kin of the rule (output/parameter)
+    - [typ]: The type of the rule (optional) *)
+type model_output =
+  { rule_name: Rule_name.t
+  ; parameters: Rule_name.t list
+  ; meta: Shared_ast.rule_meta list
+  ; is_output: bool
+  ; typ: Typ.t option }
+
+(** A list of model outputs representing all the public API of a model. *)
+type t = model_output list

--- a/packages/compiler/lib/utils/dune
+++ b/packages/compiler/lib/utils/dune
@@ -3,5 +3,6 @@
  (public_name publicodes.utils)
  (libraries base stdune ppx_deriving jingoo fpath)
  (modules :standard)
+ (preprocessor_deps (env_var PUBLICODESPATH))
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare)))
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare ppx_comptime_env)))

--- a/packages/compiler/lib/utils/err.ml
+++ b/packages/compiler/lib/utils/err.ml
@@ -46,6 +46,7 @@ module Code = struct
     | Parsing_missing_value
     | Invalid_path
     | Invalid_config
+    | Resolver_duplicate_rule
   [@@deriving equal, enum, show]
 
   let show = fun code -> Stdlib.Format.sprintf "E%03d" (to_enum code)
@@ -128,6 +129,9 @@ let missing_parent_rule =
   (Code.Resolver_missing_parent_rule, "règle parente manquante")
 
 let missing_rule = (Code.Resolver_missing_rule, "cette règle n'existe pas")
+
+let duplicate_rule =
+  (Code.Resolver_duplicate_rule, "cette règle existe en double")
 
 let malformed_expression =
   (Code.Parsing_missing_closing_paren, "expression malformée")

--- a/packages/compiler/lib/utils/err.ml
+++ b/packages/compiler/lib/utils/err.ml
@@ -47,6 +47,7 @@ module Code = struct
     | Invalid_path
     | Invalid_config
     | Resolver_duplicate_rule
+    | Unused_context
   [@@deriving equal, enum, show]
 
   let show = fun code -> Stdlib.Format.sprintf "E%03d" (to_enum code)
@@ -159,3 +160,6 @@ let import_cycle chain =
     |> Stdlib.Format.sprintf "cycle d'import détecté : %s"
   in
   (Code.Cycle_detected, message)
+
+let unused_context =
+  (Code.Unused_context, "certaines règles du contexte non utilisées")

--- a/packages/compiler/lib/utils/err.ml
+++ b/packages/compiler/lib/utils/err.ml
@@ -48,6 +48,7 @@ module Code = struct
     | Invalid_config
     | Resolver_duplicate_rule
     | Unused_context
+    | Parsing_no_rules
   [@@deriving equal, enum, show]
 
   let show = fun code -> Stdlib.Format.sprintf "E%03d" (to_enum code)
@@ -163,3 +164,6 @@ let import_cycle chain =
 
 let unused_context =
   (Code.Unused_context, "certaines règles du contexte non utilisées")
+
+let no_rules =
+  (Code.Parsing_no_rules, "aucune règle trouvée dans le fichier ou le stream")

--- a/packages/compiler/lib/utils/file.ml
+++ b/packages/compiler/lib/utils/file.ml
@@ -118,8 +118,12 @@ let find_package current_package path =
       match Stdlib.Sys.getenv_opt "PUBLICODESPATH" with
       | Some value ->
           Ok value
-      | None ->
-          Error Absent_env
+      | None -> (
+        match [%comptime_env_opt "PUBLICODESPATH"] with
+        | Some value ->
+            Ok value
+        | None ->
+            Error Absent_env )
     in
     let values =
       String.split value ~on:':'

--- a/packages/compiler/lib/utils/file.ml
+++ b/packages/compiler/lib/utils/file.ml
@@ -114,16 +114,19 @@ let find_package current_package path =
         Error (Invalid_path path)
   in
   let* vendors =
-    let* values_str =
+    let* value =
       match Stdlib.Sys.getenv_opt "PUBLICODESPATH" with
+      | Some value ->
+          Ok value
       | None ->
           Error Absent_env
-      | Some value ->
-          let values =
-            String.split value ~on:':'
-            |> List.filter ~f:(fun part -> String.is_empty part |> not)
-          in
-          if List.is_empty values then Error Empty_env else Ok values
+    in
+    let values =
+      String.split value ~on:':'
+      |> List.filter ~f:(fun part -> String.is_empty part |> not)
+    in
+    let* values_str =
+      if List.is_empty values then Error Empty_env else Ok values
     in
     let values = List.map values_str ~f:Fpath.of_string in
     if List.filter values ~f:Result.is_error |> List.is_empty then Ok values_str

--- a/packages/compiler/lib/yaml_parser/parse.ml
+++ b/packages/compiler/lib/yaml_parser/parse.ml
@@ -123,8 +123,8 @@ let parse (filename : string) (content : string) : yaml Output.t =
             return result
         | token ->
             unexpected_token_error token "the end of stream" )
-    | token ->
-        unexpected_token_error token "the beginning of stream"
+    | _ ->
+        fatal_error_from_current_token Err.no_rules
   and parse_document () =
     let* document_start, _ = next () in
     match document_start with
@@ -137,8 +137,8 @@ let parse (filename : string) (content : string) : yaml Output.t =
             return result
         | token ->
             unexpected_token_error token "the end of file" )
-    | token ->
-        unexpected_token_error token "the beginning of file"
+    | _ ->
+        fatal_error_from_current_token Err.no_rules
   and parse_node () =
     let event, pos = !current_token in
     match event with

--- a/packages/compiler/tests/crams/compile/context/arguments.t/input/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/context/arguments.t/input/rules.publicodes
@@ -1,0 +1,17 @@
+a:
+  type: nombre
+b:
+  type: nombre
+c:
+  type: nombre
+d:
+  valeur: a
+e:
+  valeur: a + b + c + d
+  contexte:
+    a: 20
+out:
+  valeur: e
+  public: oui
+  contexte:
+    b: 10

--- a/packages/compiler/tests/crams/compile/context/arguments.t/run.t
+++ b/packages/compiler/tests/crams/compile/context/arguments.t/run.t
@@ -1,0 +1,58 @@
+Valid :
+
+  $ publicodes compile input -o - | awk '
+  > /^ *$/ { next }
+  > /const rules = {/ { enabled=1 }
+  > /export default rules;/ { enabled=0 }
+  > enabled { print }
+  > '
+  const rules = {
+    'c': {
+      /**
+       * Parameters of "c"
+       * @typedef {{
+       *  'c'?: number
+       * }} cParams
+       */
+      /**
+       * Evaluate "c" with evaluation trace, and information on
+       * missing and needed parameters.
+       * @type {(params?: cParams, options?: {Options}) => {value: number, needed: Array<keyof cParams>, missing: Array<keyof cParams>, trace: {Trace}}}
+       */
+      evaluate: (params = {}, options) =>
+        $evaluate(_c, params, options),
+      /** @type {"number"} */
+      type: "number",
+      /** @type {"aucune"} */
+      unit: "aucune",
+      /**
+       * Parameter list for "c"
+       * @type {Array<keyof cParams>}
+       */
+      params: ['c'],
+    },
+    'out': {
+      /**
+       * Parameters of "out"
+       * @typedef {{
+       *  'c'?: number
+       * }} outParams
+       */
+      /**
+       * Evaluate "out" with evaluation trace, and information on
+       * missing and needed parameters.
+       * @type {(params?: outParams, options?: {Options}) => {value: number, needed: Array<keyof outParams>, missing: Array<keyof outParams>, trace: {Trace}}}
+       */
+      evaluate: (params = {}, options) =>
+        $evaluate(_out, params, options),
+      /** @type {"number"} */
+      type: "number",
+      /** @type {"aucune"} */
+      unit: "aucune",
+      /**
+       * Parameter list for "out"
+       * @type {Array<keyof outParams>}
+       */
+      params: ['c'],
+    }
+  }

--- a/packages/compiler/tests/crams/compile/context/arguments.t/run.t
+++ b/packages/compiler/tests/crams/compile/context/arguments.t/run.t
@@ -56,3 +56,9 @@ Valid :
       params: ['c'],
     }
   }
+  export const parameters = {
+    'c': rules['c'],
+  }
+  export const outputs = {
+    'out': rules['out'],
+  }

--- a/packages/compiler/tests/crams/compile/context/unused.t/override/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/context/unused.t/override/rules.publicodes
@@ -1,0 +1,9 @@
+a:
+  valeur: b
+  contexte:
+    c: 1  # doit lever une erreur
+b:
+  valeur: c
+  contexte:
+    c: 2  # override
+c:

--- a/packages/compiler/tests/crams/compile/context/unused.t/run.t
+++ b/packages/compiler/tests/crams/compile/context/unused.t/run.t
@@ -1,0 +1,23 @@
+Invalid :
+
+  $ publicodes compile unused -t debug_eval_tree -o -
+  E038 certaines règles du contexte non utilisées
+  [syntax error]
+       ╒══  unused/rules.publicodes:2:3 ══
+     1 │ a:
+     2 │   contexte:
+       │   ˘˘˘˘˘˘˘˘˘
+   Hint: ces contextes ne sont pas utilisés :
+         - b
+  [123]
+
+  $ publicodes compile override -t debug_eval_tree -o -
+  E038 certaines règles du contexte non utilisées
+  [syntax error]
+       ╒══  override/rules.publicodes:3:3 ══
+     2 │   valeur: b
+     3 │   contexte:
+       │   ˘˘˘˘˘˘˘˘˘
+   Hint: ces contextes ne sont pas utilisés :
+         - c
+  [123]

--- a/packages/compiler/tests/crams/compile/context/unused.t/unused/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/context/unused.t/unused/rules.publicodes
@@ -1,0 +1,5 @@
+a:
+  contexte:
+    b: 4  # doit lever une erreur
+  valeur: 5
+b:

--- a/packages/compiler/tests/crams/compile/duplicate_rule.t/duplicate/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/duplicate_rule.t/duplicate/rules.publicodes
@@ -1,0 +1,12 @@
+regle a: 10
+regle a: 20
+
+module b:
+  importer: module b
+  avec:
+    regle b: 20
+
+regle c . regle d: 20
+regle c:
+  avec:
+    regle d: 30

--- a/packages/compiler/tests/crams/compile/duplicate_rule.t/module b/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/duplicate_rule.t/module b/rules.publicodes
@@ -1,0 +1,3 @@
+regle b:
+  valeur: 20
+  public: oui

--- a/packages/compiler/tests/crams/compile/duplicate_rule.t/run.t
+++ b/packages/compiler/tests/crams/compile/duplicate_rule.t/run.t
@@ -1,0 +1,36 @@
+Les erreurs :
+
+  $ publicodes compile duplicate -t debug_eval_tree -o -
+  E037 cette règle existe en double [syntax error]
+       ╒══  duplicate/rules.publicodes:1:1 ══
+     1 │ regle a: 10
+       │ ˘˘˘˘˘˘˘˘ définie ici
+       ╒══  duplicate/rules.publicodes:2:1 ══
+     1 │ regle a: 10
+     2 │ regle a: 20
+       │ ˘˘˘˘˘˘˘˘ définie ici
+   Hint: La règle `regle a` est définie plusieurs
+         fois
+  E037 cette règle existe en double [syntax error]
+       ╒══  duplicate/rules.publicodes:7:5 ══
+     6 │   avec:
+     7 │     regle b: 20
+       │     ˘˘˘˘˘˘˘˘ définie ici
+       ╒══  module b/rules.publicodes:1:1 ══
+     1 │ regle b:
+       │ ˘˘˘˘˘˘˘˘ définie ici
+   Hint: La règle `module b . regle b` est définie
+         plusieurs fois
+  E037 cette règle existe en double [syntax error]
+       ╒══  duplicate/rules.publicodes:9:1 ══
+     8 │ 
+     9 │ regle c . regle d: 20
+       │ ˘˘˘˘˘˘˘˘˘˘˘˘˘˘˘˘˘˘ définie ici
+       ╒══  duplicate/rules.publicodes:12:5 ══
+    11 │   avec:
+    12 │     regle d: 30
+       │     ˘˘˘˘˘˘˘˘ définie ici
+   Hint: La règle `regle c . regle d` est définie
+         plusieurs fois
+  [123]
+

--- a/packages/compiler/tests/crams/compile/empty_file.t/run.t
+++ b/packages/compiler/tests/crams/compile/empty_file.t/run.t
@@ -9,3 +9,23 @@ Affiche une erreur si le dossier est vide :
   $ publicodes compile empty
   Error: Directory does not contains Publicodes files
   [124]
+
+Affiche une erreur si le fichier est vide :
+
+  $ publicodes compile empty_file
+  E039
+  aucune règle trouvée dans le fichier ou le stream [yaml error]
+       ╒══  empty_file/rules.publicodes:1:1 ══
+  
+  [123]
+
+Affiche une erreur si le stream stdin est vide :
+
+  $ publicodes compile -
+  E039
+  aucune règle trouvée dans le fichier ou le stream [yaml error]
+  <no
+  source
+  available>
+  
+  [123]

--- a/packages/compiler/tests/crams/compile/imports.t/run.t
+++ b/packages/compiler/tests/crams/compile/imports.t/run.t
@@ -80,6 +80,12 @@ Check root exports :
       params: ['module c . regle c'],
     }
   }
+  export const parameters = {
+    'module c . regle c': rules['module c . regle c'],
+  }
+  export const outputs = {
+    'result': rules['result'],
+  }
 
 Cycle imports :
 

--- a/packages/compiler/tests/runtimes/JS/src/mecanismes/contexte.test.ts
+++ b/packages/compiler/tests/runtimes/JS/src/mecanismes/contexte.test.ts
@@ -79,8 +79,8 @@ test:
 		// Lors de plusieurs contextes imbriqués, le contexte le plus profond a la priorité.
 		const engine = await yaml`
 x:
-  # valeur attendue: 3
-  valeur: y
+  # valeur attendue: 4
+  valeur: y + a
   contexte:
     a: 1
     b: 1
@@ -96,7 +96,7 @@ a: 0
 b: 0
 `
 		expect(engine['x'].evaluate()).toMatchObject({
-			value: 3,
+			value: 4,
 			missing: [],
 		})
 


### PR DESCRIPTION
Currently we export the whole ruleset as the default export. We keep this merged ruleset, but we also export outputs and parameters separately.

Implements: https://github.com/publicodes/publicodes/issues/780