### PR TITLE
feat: improve import cycle error reporting

### DIFF
--- a/packages/compiler/lib/parser/dune
+++ b/packages/compiler/lib/parser/dune
@@ -2,7 +2,7 @@
  (inline_tests)
  (name parser)
  (public_name publicodes.parser)
- (libraries yaml_parser base utils expr shared fpath)
+ (libraries yaml_parser base utils expr shared)
  (modules :standard)
  (preprocess
   (pps

--- a/packages/compiler/lib/parser/parse.ml
+++ b/packages/compiler/lib/parser/parse.ml
@@ -148,7 +148,7 @@ and parse_import ~default_to_public ~ctx mapping =
   match find_value "importer" mapping with
   | None ->
       return []
-  | Some (value, pos) -> (
+  | Some (value, pos) ->
       let* package, (module_, pos) =
         match value with
         | `A _ ->
@@ -202,23 +202,52 @@ and parse_import ~default_to_public ~ctx mapping =
         | Ok files ->
             return files
       in
-      let circular_files =
-        List.find input_files ~f:(fun filename ->
-            List.exists ctx.files ~f:(String.equal filename) )
-      in
-      match circular_files with
-      | Some circular ->
-          let code, message = Err.import_cycle (circular :: ctx.files) in
-          fatal_error ~pos ~code ~kind:`Syntax message
-      | None ->
-          let input_files = List.map ~f:(fun value -> value) input_files in
-          parse_files ~default_to_public
-            ~ctx:{ctx with current_package= package; current_module= module_}
-            input_files )
+      let input_files = List.map ~f:(fun value -> value) input_files in
+      parse_files ~default_to_public ~pos
+        ~ctx:{ctx with current_package= package; current_module= module_}
+        input_files
 
-and parse_files ~default_to_public ~ctx input_files =
+and parse_files ~default_to_public ~ctx ?(pos = Pos.dummy) input_files =
   let module_id = !(ctx.next_module_id) in
   ctx.next_module_id := !(ctx.next_module_id) + 1 ;
+  let new_module_id =
+    Shared.Module_id.append ctx.current_module_id (Pos.mk ~pos module_id)
+  in
+  let* _ =
+    let circular_file =
+      List.find_map input_files ~f:(fun input_file ->
+          List.findi ctx.files ~f:(fun _ file -> String.equal input_file file) )
+    in
+    match circular_file with
+    | None ->
+        return []
+    | Some (circular_i, circular_file) ->
+        let labels =
+          let module_ids =
+            Shared.Module_id.to_list new_module_id
+            |> List.filter ~f:(fun module_ ->
+                Pos.equal_pos (Pos.pos module_) Pos.dummy |> not )
+          in
+          List.mapi module_ids ~f:(fun i (_, pos) ->
+              let msg =
+                if i < List.length module_ids - 1 then
+                  let _, file =
+                    List.findi_exn ctx.files ~f:(fun y _ -> y = i + 1)
+                  in
+                  let dir = File.dirname file in
+                  if i = circular_i then
+                    Stdlib.Format.sprintf
+                      "module '%s' importé ici, début du cycle" dir
+                  else Stdlib.Format.sprintf "module '%s' importé ici" dir
+                else
+                  let dir = File.dirname circular_file in
+                  Stdlib.Format.sprintf "module '%s' importé à nouveau ici" dir
+              in
+              Pos.mk ~pos msg )
+        in
+        let code, message = Err.import_cycle in
+        fatal_error ~pos ~labels ~code ~kind:`Syntax message
+  in
   let+ unresolved_programs =
     List.map input_files ~f:(fun filename ->
         (* Read the file content *)
@@ -229,9 +258,8 @@ and parse_files ~default_to_public ~ctx input_files =
               ~pos:(Pos.beginning_of_file filename)
               ~ctx:
                 { ctx with
-                  files= filename :: ctx.files
-                ; current_module_id=
-                    Shared.Module_id.append ctx.current_module_id module_id } )
+                  files= ctx.files @ [filename]
+                ; current_module_id= new_module_id } )
     |> all_keep_logs
   in
   List.fold

--- a/packages/compiler/lib/shared/module_id.ml
+++ b/packages/compiler/lib/shared/module_id.ml
@@ -1,10 +1,13 @@
 open Base
+open Utils
 
 module T = struct
   module T_ = struct
-    type t = int list [@@deriving equal, compare, sexp]
+    type t = int Pos.t list [@@deriving equal, compare, sexp]
 
-    let show a = List.map a ~f:Int.to_string |> String.concat ~sep:" . "
+    let show a =
+      List.map a ~f:(fun a -> Pos.value a |> Int.to_string)
+      |> String.concat ~sep:" . "
 
     let pp ppf module_id = Stdlib.Format.fprintf ppf "%s" (show module_id)
   end
@@ -25,8 +28,10 @@ let is_parent module_a module_b =
 
 let empty = []
 
-let root = [0]
+let root = [Pos.mk ~pos:Pos.dummy 0]
 
 let is_root module_ = equal module_ root
 
 let append module_ id = module_ @ [id]
+
+let to_list module_ = module_

--- a/packages/compiler/lib/shared/module_id.mli
+++ b/packages/compiler/lib/shared/module_id.mli
@@ -1,4 +1,5 @@
 open Base
+open Utils
 
 module T : sig
   type t [@@deriving equal, compare, show, sexp]
@@ -19,14 +20,14 @@ val is_parent : T.t -> T.t -> bool
 (** [is_parent module_a module_b] returns true if the module_b is a child of
 module_a *)
 
-val root : int list
-(** [root] returns the root module_id *)
-
 val is_root : T.t -> bool
 (** [is_root module] returns true if module is the root module *)
 
-val append : T.t -> int -> T.t
+val append : T.t -> int Pos.t -> T.t
 (** [append module id] push a module id to the module_id *)
 
 val empty : T.t
 (** [empty] returns the empty module_id *)
+
+val to_list : T.t -> int Pos.t list
+(** [to_list module] return the module id as list *)

--- a/packages/compiler/lib/utils/dune
+++ b/packages/compiler/lib/utils/dune
@@ -4,4 +4,5 @@
  (libraries base stdune ppx_deriving jingoo fpath)
  (modules :standard)
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare)))
+  (pps ppx_inline_test ppx_assert ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare))
+ (inline_tests))

--- a/packages/compiler/lib/utils/err.ml
+++ b/packages/compiler/lib/utils/err.ml
@@ -155,12 +155,7 @@ let invalid_path = (Code.Invalid_path, "chemin invalide")
 
 let invalid_config = (Code.Invalid_config, "configuration invalide")
 
-let import_cycle chain =
-  let message =
-    String.concat " <- " chain
-    |> Stdlib.Format.sprintf "cycle d'import détecté : %s"
-  in
-  (Code.Cycle_detected, message)
+let import_cycle = (Code.Cycle_detected, "cycle d'import détecté")
 
 let unused_context =
   (Code.Unused_context, "certaines règles du contexte non utilisées")

--- a/packages/compiler/lib/utils/file.ml
+++ b/packages/compiler/lib/utils/file.ml
@@ -161,3 +161,17 @@ let find_package current_package path =
       Ok directory
   | None ->
       Error (Not_found paths)
+
+let dirname path =
+  let path = Fpath.of_string path |> Stdlib.Result.get_ok in
+  let segs = Fpath.segs path |> List.drop_last_exn in
+  let hd, rest =
+    match segs with [] -> ("./", []) | hd :: rest -> (hd, rest)
+  in
+  let acc = Fpath.v hd in
+  List.fold rest ~init:acc ~f:Fpath.add_seg |> Fpath.to_string
+
+let%test_unit "dirname" =
+  [%test_eq: string] (dirname "foo/bar/toot.publicodes") "foo/bar" ;
+  [%test_eq: string] (dirname "foo/bar/") "foo/bar" ;
+  [%test_eq: string] (dirname "foo") "./"

--- a/packages/compiler/lib/utils/file.mli
+++ b/packages/compiler/lib/utils/file.mli
@@ -39,3 +39,7 @@ val find_package :
   string option -> string -> (string, find_package_error) result
 (** [publicodes_package ~current_package ~path] finds the path to the package
   directory. *)
+
+val dirname : string -> string
+(* [dirname ~path] Returns the directory path of a file or directory path.
+  Raise an exception for invalid or empty path. *)

--- a/packages/compiler/tests/crams/compile/imports.t/cycle b/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/imports.t/cycle b/rules.publicodes
@@ -1,2 +1,2 @@
-cycle a:
-  importer: cycle a
+cycle c:
+  importer: cycle c

--- a/packages/compiler/tests/crams/compile/imports.t/cycle c/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/imports.t/cycle c/rules.publicodes
@@ -1,0 +1,2 @@
+cycle a:
+  importer: cycle a

--- a/packages/compiler/tests/crams/compile/imports.t/run.t
+++ b/packages/compiler/tests/crams/compile/imports.t/run.t
@@ -90,13 +90,23 @@ Check root exports :
 Cycle imports :
 
   $ publicodes compile subjects/cycle -t debug_eval_tree -o -
-  E027
-  cycle d'import détecté : cycle a/rules.publicodes <- cycle b/rules.publicodes <- cycle a/rules.publicodes <- subjects/cycle/main.publicodes
-  [syntax error]
-       ╒══  cycle b/rules.publicodes:2:13 ══
+  E027 cycle d'import détecté [syntax error]
+       ╒══  subjects/cycle/main.publicodes:2:13 ══
      1 │ cycle a:
      2 │   importer: cycle a
-       │             ˘˘˘˘˘˘˘
+       │             ˘˘˘˘˘˘˘ module 'cycle a' importé ici
+       ╒══  cycle a/rules.publicodes:2:13 ══
+     1 │ cycle b:
+     2 │   importer: cycle b
+       │             ˘˘˘˘˘˘˘ module 'cycle b' importé ici, début du cycle
+       ╒══  cycle b/rules.publicodes:2:13 ══
+     1 │ cycle c:
+     2 │   importer: cycle c
+       │             ˘˘˘˘˘˘˘ module 'cycle c' importé ici
+       ╒══  cycle c/rules.publicodes:2:13 ══
+     1 │ cycle a:
+     2 │   importer: cycle a
+       │             ˘˘˘˘˘˘˘ module 'cycle a' importé à nouveau ici
   
   [123]
 


### PR DESCRIPTION
This refactorize a bit, and improve how we report import cycling errors:

	E027 cycle d'import détecté [syntax error]
	     ╒══  subjects/cycle/main.publicodes:2:13 ══
	   1 │ cycle a:
	   2 │   importer: cycle a
	     │             ˘˘˘˘˘˘˘ importé ici
	     ╒══  cycle a/rules.publicodes:2:13 ══
	   1 │ cycle b:
	   2 │   importer: cycle b
	     │             ˘˘˘˘˘˘˘ re-boucle ici
	     ╒══  cycle b/rules.publicodes:2:13 ══
	   1 │ cycle c:
	   2 │   importer: cycle c
	     │             ˘˘˘˘˘˘˘ importé ici
	     ╒══  cycle c/rules.publicodes:2:13 ══
	   1 │ cycle a:
	   2 │   importer: cycle a
	     │             ˘˘˘˘˘˘˘ boucle ici