### PR TITLE
feat: build with a default PUBLICODESPATH

### DIFF
--- a/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
+++ b/packages/compiler/lib/ppx_comptime_env/comptime_env.ml
@@ -1,0 +1,23 @@
+open Ppxlib
+
+let expand ~ctxt env_var =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  match Sys.getenv env_var with
+  | value ->
+      let ident = Longident.parse "Some" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      let value = Ast_builder.Default.estring ~loc value in
+      Ast_builder.Default.pexp_construct ~loc loc_ident (Some value)
+  | exception Not_found ->
+      let ident = Longident.parse "None" in
+      let loc_ident = Ast_builder.Default.Located.mk ~loc ident in
+      Ast_builder.Default.pexp_construct ~loc loc_ident None
+
+let my_extension =
+  Extension.V3.declare "comptime_env_opt" Extension.Context.expression
+    Ast_pattern.(single_expr_payload (estring __))
+    expand
+
+let rule = Ppxlib.Context_free.Rule.extension my_extension
+
+let () = Driver.register_transformation ~rules:[rule] "comptime_env_opt"

--- a/packages/compiler/lib/ppx_comptime_env/dune
+++ b/packages/compiler/lib/ppx_comptime_env/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_comptime_env)
+ (public_name publicodes.ppx_comptime_env)
+ (kind ppx_rewriter)
+ (libraries ppxlib))

--- a/packages/compiler/lib/utils/dune
+++ b/packages/compiler/lib/utils/dune
@@ -3,5 +3,6 @@
  (public_name publicodes.utils)
  (libraries base stdune ppx_deriving jingoo fpath)
  (modules :standard)
+ (preprocessor_deps (env_var PUBLICODESPATH))
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare)))
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.enum ppx_compare ppx_comptime_env)))

--- a/packages/compiler/lib/utils/file.ml
+++ b/packages/compiler/lib/utils/file.ml
@@ -118,8 +118,12 @@ let find_package current_package path =
       match Stdlib.Sys.getenv_opt "PUBLICODESPATH" with
       | Some value ->
           Ok value
-      | None ->
-          Error Absent_env
+      | None -> (
+        match [%comptime_env_opt "PUBLICODESPATH"] with
+        | Some value ->
+            Ok value
+        | None ->
+            Error Absent_env )
     in
     let values =
       String.split value ~on:':'


### PR DESCRIPTION
This add a preprocessor "comptime_env_opt" to build compilers with a default value for PUBLICODESPATH. We will use this when packaging a node Publicode package, so that it fallback to the value when absent "./node_modules:node_modules".

Change-Id: Ib32c1aa24817416ec0da39957fdc7be56a6a6964