### PR TITLE
Failing test : problem with avec and cycle

### DIFF
--- a/packages/compiler/tests/crams/compile/avec.t/input/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/avec.t/input/rules.publicodes
@@ -1,0 +1,4 @@
+avec et cycle:
+  avec:
+    b:
+      valeur: b

--- a/packages/compiler/tests/crams/compile/avec.t/run.t
+++ b/packages/compiler/tests/crams/compile/avec.t/run.t
@@ -1,0 +1,3 @@
+Avec :
+
+  $ publicodes compile input -o -


### PR DESCRIPTION
Petit problème lorsque l'on utilise `avec`  et qu'il y a un cycle, je ne sais pas pourquoi
```
File "tests/crams/compile/avec.t/run.t", line 1, characters 0-0:
diff --git a/_build/default/tests/crams/compile/avec.t/run.t b/_build/default/tests/crams/compile/avec.t/run.t.corrected
index 0811e8d..0b42200 100644
--- a/_build/default/tests/crams/compile/avec.t/run.t
+++ b/_build/default/tests/crams/compile/avec.t/run.t.corrected
@@ -1,3 +1,12 @@
 Avec :

   $ publicodes compile input -o -
+  E020 cette règle n'existe pas [syntax error]
+       ╒══  input/rules.publicodes:4:15 ══
+     3 │     b:
+     4 │       valeur: b
+       │               ˘
+   Hint: Ajoutez la règle `b` manquante
+   Hint: Vérifiez les erreurs de typos dans le nom de la
+         règle
+  [123]
```