### PR TITLE
fix: context used check broken when encountering the override first

### DIFF
--- a/packages/compiler/lib/dependency_graph/checks.ml
+++ b/packages/compiler/lib/dependency_graph/checks.ml
@@ -68,7 +68,7 @@ let unused_context_check (tree : 'a Eval_tree.t) (graph : Rule_graph.t) :
         let deps = Rule_graph.succ graph from in
         if List.exists ctxs ~f:(Rule_name.equal ctx) then
           (* the context is override here *)
-          false
+          is_used ctx rest
         else if List.exists deps ~f:(Rule_name.equal ctx) then
           (* the context is actually used here *)
           true

--- a/packages/compiler/tests/crams/compile/context/unused.t/run.t
+++ b/packages/compiler/tests/crams/compile/context/unused.t/run.t
@@ -19,3 +19,30 @@ Invalid :
        │     ˘˘ contexte inutilisé
   
   [123]
+
+  $ publicodes compile works -t debug_eval_tree -o -
+  x:
+    with
+    {
+    x . a = 1.
+    x . b = 1.
+    }
+    in
+    @x . y + @x . w
+  
+  x . a:
+    0.
+  
+  x . b:
+    0.
+  
+  x . w:
+    @x . a
+  
+  x . y:
+    with
+    {
+    x . a = 2.
+    }
+    in
+    @x . a + @x . b

--- a/packages/compiler/tests/crams/compile/context/unused.t/works/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/context/unused.t/works/rules.publicodes
@@ -1,0 +1,13 @@
+x:
+  valeur: y + w
+  contexte:
+    a: 1
+    b: 1
+  avec:
+    y:
+      valeur: a + b
+      contexte:
+        a: 2
+    w: a
+    a: 0
+    b: 0


### PR DESCRIPTION
The change related to the finite recursive algorithm broke this.

Change-Id: Ica8b390f3c48ebf056909af2ffc787226a6a6964