### PR TITLE
fix: resolve the parent rule if the name is the same

### DIFF
--- a/packages/compiler/lib/dependency_graph/checks.ml
+++ b/packages/compiler/lib/dependency_graph/checks.ml
@@ -104,4 +104,4 @@ let checks ~(ast : 'a Shared_ast.t) ~(eval_tree : Hashed_tree.t) :
   let access_logs = illegal_check ast graph in
   let context_logs = unused_context_check eval_tree graph in
   let logs = cycle_logs @ access_logs @ context_logs in
-  return ~logs graph
+  break ~logs graph

--- a/packages/compiler/lib/shared/rule_name.ml
+++ b/packages/compiler/lib/shared/rule_name.ml
@@ -71,7 +71,8 @@ let resolve ~rule_names ~current name =
       Some x
   (* If no matching, we check if the current rule is a match *)
   | None ->
-      if String.equal (to_string current) (to_string name) then Some current
+      let parent = List.hd_exn parent_paths in
+      if String.equal (to_string current) (to_string parent) then Some current
       else None
 
 let make_reserved uid = [Printf.sprintf "__%s" uid]

--- a/packages/compiler/lib/utils/output.ml
+++ b/packages/compiler/lib/utils/output.ml
@@ -6,6 +6,9 @@ let empty : 'a t = (None, [])
 
 let return ?(logs = []) x : 'a t = (Some x, logs)
 
+let break ?(logs = []) x : 'a t =
+  match logs with [] -> (Some x, []) | _ -> (None, logs)
+
 let result (x, _) = x
 
 let logs (_, logs) = logs

--- a/packages/compiler/tests/crams/compile/avec.t/input/rules.publicodes
+++ b/packages/compiler/tests/crams/compile/avec.t/input/rules.publicodes
@@ -1,0 +1,4 @@
+avec et cycle:
+  avec:
+    b:
+      valeur: b

--- a/packages/compiler/tests/crams/compile/avec.t/run.t
+++ b/packages/compiler/tests/crams/compile/avec.t/run.t
@@ -1,0 +1,10 @@
+Avec :
+
+  $ publicodes compile input -o -
+  E027 cycle de dépendance détecté [cycle warning]
+       ╒══  input/rules.publicodes:4:15 ══
+     3 │     b:
+     4 │       valeur: b
+       │               ˘
+   Hint: avec et cycle . b -> avec et cycle . b
+  [123]

--- a/packages/compiler/tests/crams/compile/with.t/run.t
+++ b/packages/compiler/tests/crams/compile/with.t/run.t
@@ -2,12 +2,10 @@
 Valid avec @FIXME
 
   $ publicodes compile valid -o -
-  E020 cette règle n'existe pas [syntax error]
+  E027 cycle de dépendance détecté [cycle warning]
        ╒══  valid/rules.publicodes:9:8 ══
      8 │   avec:
      9 │     e: e
        │        ˘
-   Hint: Ajoutez la règle `e` manquante
-   Hint: Vérifiez les erreurs de typos dans le nom de la
-         règle
+   Hint: d . e -> d . e
   [123]


### PR DESCRIPTION
Currently this None case seems to not be used by any test we have. I
suspect it is wrong, and should match the parent rule instead.

This change the error we get in an existing test, but we also add the
test reported here: https://github.com/publicodes/publicodes/pull/835

Change-Id: If34a0873cefd82ae9b2dde47561f21086a6a6964

related to: https://github.com/publicodes/publicodes/pull/835